### PR TITLE
Add lintel beam, framing splines, and fix course join lines

### DIFF
--- a/devpro-wall-builder/src/components/EpsElevation.jsx
+++ b/devpro-wall-builder/src/components/EpsElevation.jsx
@@ -535,7 +535,7 @@ export default function EpsElevation({ layout, wallName }) {
             );
           })}
 
-          {/* ── Lintels (trapezoid for raked/gable — magboard) ── */}
+          {/* ── Lintels (timber beam + EPS fill above) ── */}
           {lintels.map((l, i) => {
             const hL = l.heightLeft != null ? l.heightLeft : l.height;
             const hR = l.heightRight != null ? l.heightRight : l.height;
@@ -544,13 +544,89 @@ export default function EpsElevation({ layout, wallName }) {
             const yBase = s(yBottom - l.y);
             const yTopL = s(yBottom - l.y - hL);
             const yTopR = s(yBottom - l.y - hR);
-            const pts = l.peakHeight
+            const outlinePts = l.peakHeight
               ? `${x1},${yBase} ${x1},${yTopL} ${s(l.x + l.peakXLocal)},${s(yBottom - l.y - l.peakHeight)} ${x2},${yTopR} ${x2},${yBase}`
               : `${x1},${yBase} ${x1},${yTopL} ${x2},${yTopR} ${x2},${yBase}`;
+
+            // Find the matching opening for spline positions
+            const op = openings.find(o => o.ref === l.ref);
+            const hasSill = op && op.y > 0;
+
+            // Timber beam spans between inner edges of opening splines/plates, with 10mm gap
+            const beamH = l.beamHeight || 200;
+            const beamLeft = hasSill
+              ? op.x - BOTTOM_PLATE + EPS_INSET            // 10mm inside left spline inner edge
+              : op.x - BOTTOM_PLATE + EPS_INSET;           // 10mm inside left plate inner edge
+            const beamRight = hasSill
+              ? op.x + op.drawWidth + BOTTOM_PLATE - EPS_INSET  // 10mm inside right spline inner edge
+              : op.x + op.drawWidth + BOTTOM_PLATE - EPS_INSET; // 10mm inside right plate inner edge
+            const beamTop = yBottom - l.y - beamH;
+            const beamBot = yBottom - l.y;
+
+            // Lintel EPS: fills the area above the timber beam, inset 10mm from spline/plate inner edges
+            const epsLeft = op.x - BOTTOM_PLATE + EPS_INSET;     // 10mm inside spline/plate inner edge
+            const epsRight = op.x + op.drawWidth + BOTTOM_PLATE - EPS_INSET;  // 10mm inside spline/plate inner edge
+            const epsBot = beamTop - EPS_INSET;  // 10mm above timber beam
+
+            // EPS top follows wall slope (same as panel EPS logic)
+            const epsTopAt = (x) => yTopAt(x) + TOP_PLATE * 2 + EPS_INSET;
+
             const midH = Math.max(hL, hR, l.peakHeight || 0) / 2;
+
+            // Build EPS polygon (if there's space above the beam)
+            let epsPoly = null;
+            if (epsBot > epsTopAt(epsLeft) || epsBot > epsTopAt(epsRight)) {
+              const epsTopL = epsTopAt(epsLeft);
+              const epsTopR = epsTopAt(epsRight);
+
+              if (isRaked && Math.abs(epsTopL - epsTopR) > 0.5) {
+                // Raked/gable: polygon with angled top
+                const pts = [];
+                pts.push(`${s(epsLeft)},${s(epsBot)}`);
+                pts.push(`${s(epsRight)},${s(epsBot)}`);
+                if (epsTopR < epsBot) pts.push(`${s(epsRight)},${s(epsTopR)}`);
+                // Gable peak vertex
+                if (l.peakHeight && l.peakXLocal != null) {
+                  const peakGX = l.x + l.peakXLocal;
+                  if (peakGX > epsLeft && peakGX < epsRight) {
+                    const peakTopY = epsTopAt(peakGX);
+                    if (peakTopY < epsBot) pts.push(`${s(peakGX)},${s(peakTopY)}`);
+                  }
+                }
+                if (epsTopL < epsBot) pts.push(`${s(epsLeft)},${s(epsTopL)}`);
+                if (pts.length >= 3) {
+                  epsPoly = <polygon points={pts.join(' ')} fill={EPS_FILL} stroke={EPS_STROKE} strokeWidth={1} />;
+                }
+              } else {
+                // Flat: simple rect
+                const epsTopY = Math.min(epsTopL, epsTopR);
+                const epsH = epsBot - epsTopY;
+                if (epsH > 0) {
+                  epsPoly = (
+                    <rect
+                      x={s(epsLeft)} y={s(epsTopY)}
+                      width={s(epsRight - epsLeft)} height={s(epsH)}
+                      fill={EPS_FILL} stroke={EPS_STROKE} strokeWidth={1}
+                    />
+                  );
+                }
+              }
+            }
+
             return (
               <g key={`lintel-${i}`}>
-                <polygon points={pts} fill="none" stroke={STROKE_COLOR} strokeWidth={1} />
+                {/* Lintel outline */}
+                <polygon points={outlinePts} fill="none" stroke={STROKE_COLOR} strokeWidth={1} />
+                {/* Timber beam */}
+                {op && (
+                  <rect
+                    x={s(beamLeft)} y={s(beamTop)}
+                    width={s(beamRight - beamLeft)} height={s(beamH)}
+                    fill="none" stroke={STROKE_COLOR} strokeWidth={1}
+                  />
+                )}
+                {/* EPS above beam */}
+                {epsPoly}
                 <text
                   x={s(l.x + l.width / 2)}
                   y={s(yBottom - l.y - midH / 2) + 3}
@@ -664,11 +740,20 @@ export default function EpsElevation({ layout, wallName }) {
                 const splineRight = rightEdge - HSPLINE_CLEARANCE;
                 if (splineRight <= splineLeft) return null;
 
-                // Collect lintel exclusions clipped to this spline range
+                // Collect exclusions: lintels, openings, opening plates & splines
                 const excl = [];
                 for (const l of lintels) {
                   const eL = Math.max(l.x - HSPLINE_CLEARANCE, splineLeft);
                   const eR = Math.min(l.x + l.width + HSPLINE_CLEARANCE, splineRight);
+                  if (eL < eR) excl.push([eL, eR]);
+                }
+                for (const op of openings) {
+                  const hasSill = op.y > 0;
+                  // Opening itself + vertical plates on each side
+                  const oL = op.x - BOTTOM_PLATE - (hasSill ? SPLINE_WIDTH : 0) - HSPLINE_CLEARANCE;
+                  const oR = op.x + op.drawWidth + BOTTOM_PLATE + (hasSill ? SPLINE_WIDTH : 0) + HSPLINE_CLEARANCE;
+                  const eL = Math.max(oL, splineLeft);
+                  const eR = Math.min(oR, splineRight);
                   if (eL < eR) excl.push([eL, eR]);
                 }
                 excl.sort((a, b) => a[0] - b[0]);
@@ -789,40 +874,7 @@ export default function EpsElevation({ layout, wallName }) {
 
           </g>{/* end wall-clip */}
 
-          {/* ── Course join lines (multi-course walls > 3050mm) ── */}
-          {isMultiCourse && courses.slice(1).map((course, i) => {
-            const joinY = yBottom - course.y;
-            // Compute x-extent where wall height >= course.y analytically
-            const hL = heightAt ? heightAt(0) : height;
-            const hR = heightAt ? heightAt(grossLength) : height;
-            let x0, x1;
-            if (hL >= course.y && hR >= course.y) {
-              x0 = 0; x1 = grossLength;
-            } else if (hL >= course.y) {
-              x0 = 0;
-              x1 = (course.y - hL) / (hR - hL) * grossLength;
-            } else if (hR >= course.y) {
-              x0 = (course.y - hL) / (hR - hL) * grossLength;
-              x1 = grossLength;
-            } else {
-              return null; // wall never reaches course height
-            }
-            return (
-              <g key={`course-join-${i}`}>
-                <line
-                  x1={s(x0)} y1={s(joinY)}
-                  x2={s(x1)} y2={s(joinY)}
-                  stroke="#E74C3C" strokeWidth={2} strokeDasharray="8,4"
-                />
-                <text
-                  x={s(x1) + 8} y={s(joinY) + 4}
-                  fontSize="8" fill="#E74C3C" fontWeight="bold"
-                >
-                  {course.y}
-                </text>
-              </g>
-            );
-          })}
+          {/* Course join lines removed — visible on External Elevation instead */}
 
           {/* ── Running measurement ── */}
           <g>

--- a/devpro-wall-builder/src/components/FramingElevation.jsx
+++ b/devpro-wall-builder/src/components/FramingElevation.jsx
@@ -312,20 +312,37 @@ export default function FramingElevation({ layout, wallName }) {
             const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
             if (insideLintel || insideFooter) return null;
 
-            const splineX = gapCentre - HALF_SPLINE;
-            const splineY = yTop(gapCentre) + TOP_PLATE * 2;
-            const splineH = yBottom - BOTTOM_PLATE - splineY;
-            return splineH > 0 ? (
-              <rect
+            const spXL = gapCentre - HALF_SPLINE;
+            const spXR = gapCentre + HALF_SPLINE;
+            const spTopL = yTop(spXL) + TOP_PLATE * 2;
+            const spTopR = yTop(spXR) + TOP_PLATE * 2;
+            const spBot = yBottom - BOTTOM_PLATE;
+
+            if (spTopL >= spBot && spTopR >= spBot) return null;
+
+            if (!isRaked || Math.abs(spTopL - spTopR) < 0.5) {
+              const spTopY = Math.min(spTopL, spTopR);
+              return (spBot - spTopY) > 0 ? (
+                <rect
+                  key={`joint-spline-${i}`}
+                  x={s(spXL)} y={s(spTopY)}
+                  width={s(SPLINE_WIDTH)} height={s(spBot - spTopY)}
+                  fill="none" stroke={PLATE_COLOR} strokeWidth={1} strokeDasharray={DASH}
+                />
+              ) : null;
+            }
+
+            // Raked/gable: polygon with angled top
+            const pts = [];
+            pts.push(`${s(spXL)},${s(spBot)}`);
+            pts.push(`${s(spXR)},${s(spBot)}`);
+            if (spTopR < spBot) pts.push(`${s(spXR)},${s(spTopR)}`);
+            if (spTopL < spBot) pts.push(`${s(spXL)},${s(spTopL)}`);
+            return pts.length >= 3 ? (
+              <polygon
                 key={`joint-spline-${i}`}
-                x={s(splineX)}
-                y={s(splineY)}
-                width={s(SPLINE_WIDTH)}
-                height={s(splineH)}
-                fill="none"
-                stroke={PLATE_COLOR}
-                strokeWidth={1}
-                strokeDasharray={DASH}
+                points={pts.join(' ')}
+                fill="none" stroke={PLATE_COLOR} strokeWidth={1} strokeDasharray={DASH}
               />
             ) : null;
           })}
@@ -399,22 +416,46 @@ export default function FramingElevation({ layout, wallName }) {
                   width={s(BOTTOM_PLATE)} height={opH}
                   fill="none" stroke={PLATE_COLOR} strokeWidth={1} strokeDasharray={DASH}
                 />
-                {hasSill && splineH > 0 && (
-                  <rect
-                    x={s(op.x - BOTTOM_PLATE - SPLINE_WIDTH)}
-                    y={s(splineTopY)}
-                    width={s(SPLINE_WIDTH)} height={s(splineH)}
-                    fill="none" stroke={PLATE_COLOR} strokeWidth={1} strokeDasharray={DASH}
-                  />
-                )}
-                {hasSill && splineH > 0 && (
-                  <rect
-                    x={s(op.x + op.drawWidth + BOTTOM_PLATE)}
-                    y={s(splineTopY)}
-                    width={s(SPLINE_WIDTH)} height={s(splineH)}
-                    fill="none" stroke={PLATE_COLOR} strokeWidth={1} strokeDasharray={DASH}
-                  />
-                )}
+                {hasSill && (() => {
+                  const spBot = yBottom - BOTTOM_PLATE;
+                  // Left opening spline
+                  const lSpXL = op.x - BOTTOM_PLATE - SPLINE_WIDTH;
+                  const lSpXR = op.x - BOTTOM_PLATE;
+                  const lTopL = yTop(lSpXL) + TOP_PLATE * 2;
+                  const lTopR = yTop(lSpXR) + TOP_PLATE * 2;
+                  // Right opening spline
+                  const rSpXL = op.x + op.drawWidth + BOTTOM_PLATE;
+                  const rSpXR = rSpXL + SPLINE_WIDTH;
+                  const rTopL = yTop(rSpXL) + TOP_PLATE * 2;
+                  const rTopR = yTop(rSpXR) + TOP_PLATE * 2;
+
+                  const renderSpline = (xL, xR, topL, topR, key) => {
+                    if (topL >= spBot && topR >= spBot) return null;
+                    if (!isRaked || Math.abs(topL - topR) < 0.5) {
+                      const topY = Math.min(topL, topR);
+                      return (spBot - topY) > 0 ? (
+                        <rect key={key} x={s(xL)} y={s(topY)} width={s(SPLINE_WIDTH)} height={s(spBot - topY)}
+                          fill="none" stroke={PLATE_COLOR} strokeWidth={1} strokeDasharray={DASH} />
+                      ) : null;
+                    }
+                    const pts = [];
+                    pts.push(`${s(xL)},${s(spBot)}`);
+                    pts.push(`${s(xR)},${s(spBot)}`);
+                    if (topR < spBot) pts.push(`${s(xR)},${s(topR)}`);
+                    if (topL < spBot) pts.push(`${s(xL)},${s(topL)}`);
+                    return pts.length >= 3 ? (
+                      <polygon key={key} points={pts.join(' ')}
+                        fill="none" stroke={PLATE_COLOR} strokeWidth={1} strokeDasharray={DASH} />
+                    ) : null;
+                  };
+
+                  return (
+                    <>
+                      {renderSpline(lSpXL, lSpXR, lTopL, lTopR, `op-spline-l-${i}`)}
+                      {renderSpline(rSpXL, rSpXR, rTopL, rTopR, `op-spline-r-${i}`)}
+                    </>
+                  );
+                })()}
               </g>
             );
           })}
@@ -439,7 +480,7 @@ export default function FramingElevation({ layout, wallName }) {
             </g>
           ))}
 
-          {/* ── Lintels (trapezoid for raked/gable) ── */}
+          {/* ── Lintels (trapezoid for raked/gable, with timber beam) ── */}
           {lintels.map((l, i) => {
             const hL = l.heightLeft != null ? l.heightLeft : l.height;
             const hR = l.heightRight != null ? l.heightRight : l.height;
@@ -452,9 +493,31 @@ export default function FramingElevation({ layout, wallName }) {
               ? `${x1},${yBase} ${x1},${yTopL} ${s(l.x + l.peakXLocal)},${s(yBottom - l.y - l.peakHeight)} ${x2},${yTopR} ${x2},${yBase}`
               : `${x1},${yBase} ${x1},${yTopL} ${x2},${yTopR} ${x2},${yBase}`;
             const midH = Math.max(hL, hR, l.peakHeight || 0) / 2;
+
+            // Timber beam rect (spans between vertical plates/splines with 10mm gap)
+            const op = openings.find(o => o.ref === l.ref);
+            const beamH = l.beamHeight || 200;
+            let beamEl = null;
+            if (op) {
+              const beamLeft = op.x - BOTTOM_PLATE + 10;
+              const beamRight = op.x + op.drawWidth + BOTTOM_PLATE - 10;
+              const beamTop = yBottom - l.y - beamH;
+              const beamW = beamRight - beamLeft;
+              if (beamW > 0 && beamH > 0) {
+                beamEl = (
+                  <rect
+                    x={s(beamLeft)} y={s(beamTop)}
+                    width={s(beamW)} height={s(beamH)}
+                    fill="none" stroke={STROKE_COLOR} strokeWidth={1} strokeDasharray={DASH}
+                  />
+                );
+              }
+            }
+
             return (
               <g key={`lintel-${i}`}>
                 <polygon points={pts} fill="none" stroke={STROKE_COLOR} strokeWidth={1} strokeDasharray={DASH} />
+                {beamEl}
                 <text
                   x={s(l.x + l.width / 2)}
                   y={s(yBottom - l.y - midH / 2) + 3}
@@ -579,82 +642,153 @@ export default function FramingElevation({ layout, wallName }) {
             }
             return courses.slice(1).map((course, ci) => {
               const joinY = yBottom - course.y;
+              const spTopY = joinY - HALF_SPLINE;
+              const spBotY = joinY + HALF_SPLINE;
               return panels.map((panel, pi) => {
-                let leftEdge = panel.x;
+                // Left boundary
+                let leftEdge;
                 if (pi > 0 && jointHasSpline[pi - 1]) {
                   const gc = panels[pi - 1].x + panels[pi - 1].width + PANEL_GAP / 2;
                   leftEdge = gc + HALF_SPLINE;
+                } else {
+                  leftEdge = panel.x + BOTTOM_PLATE;
                 }
-                let rightEdge = panel.x + panel.width;
+                // Right boundary
+                let rightEdge;
                 if (pi < panels.length - 1 && jointHasSpline[pi]) {
                   const gc = panel.x + panel.width + PANEL_GAP / 2;
                   rightEdge = gc - HALF_SPLINE;
+                } else {
+                  rightEdge = panel.x + panel.width - BOTTOM_PLATE;
                 }
-                const w = rightEdge - leftEdge - 2 * HSPLINE_CLEARANCE;
-                if (w <= 0) return null;
-                const x = leftEdge + HSPLINE_CLEARANCE;
-                return (
-                  <rect
-                    key={`hspline-c${ci}-p${pi}`}
-                    x={s(x)}
-                    y={s(joinY - HALF_SPLINE)}
-                    width={s(w)}
-                    height={s(SPLINE_WIDTH)}
-                    fill="none"
-                    stroke={PLATE_COLOR}
-                    strokeWidth={1}
-                    strokeDasharray={DASH}
-                  />
-                );
+
+                const splineLeft = leftEdge + HSPLINE_CLEARANCE;
+                const splineRight = rightEdge - HSPLINE_CLEARANCE;
+                if (splineRight <= splineLeft) return null;
+
+                // Collect exclusions: lintels, openings with plates & splines
+                const excl = [];
+                for (const l of lintels) {
+                  const eL = Math.max(l.x - HSPLINE_CLEARANCE, splineLeft);
+                  const eR = Math.min(l.x + l.width + HSPLINE_CLEARANCE, splineRight);
+                  if (eL < eR) excl.push([eL, eR]);
+                }
+                for (const op of openings) {
+                  const hasSill = op.y > 0;
+                  const oL = op.x - BOTTOM_PLATE - (hasSill ? SPLINE_WIDTH : 0) - HSPLINE_CLEARANCE;
+                  const oR = op.x + op.drawWidth + BOTTOM_PLATE + (hasSill ? SPLINE_WIDTH : 0) + HSPLINE_CLEARANCE;
+                  const eL = Math.max(oL, splineLeft);
+                  const eR = Math.min(oR, splineRight);
+                  if (eL < eR) excl.push([eL, eR]);
+                }
+                excl.sort((a, b) => a[0] - b[0]);
+
+                // Build segments between exclusions
+                const segs = [];
+                let cursor = splineLeft;
+                for (const [eL, eR] of excl) {
+                  if (cursor < eL) segs.push([cursor, eL]);
+                  cursor = Math.max(cursor, eR);
+                }
+                if (cursor < splineRight) segs.push([cursor, splineRight]);
+
+                return segs.map(([segL, segR], si) => {
+                  if (segR <= segL) return null;
+
+                  if (!isRaked) {
+                    return (
+                      <rect
+                        key={`hspline-c${ci}-p${pi}-s${si}`}
+                        x={s(segL)}
+                        y={s(spTopY)}
+                        width={s(segR - segL)}
+                        height={s(SPLINE_WIDTH)}
+                        fill="none"
+                        stroke={PLATE_COLOR}
+                        strokeWidth={1}
+                        strokeDasharray={DASH}
+                      />
+                    );
+                  }
+
+                  // Raked/gable: polygon clipped against wall clearance
+                  const clAt = (x) => yTop(x) + TOP_PLATE * 2;
+
+                  // Key x-positions where clearance slope changes (gable peak)
+                  const breakXs = [segL, segR];
+                  if (panel.peakHeight && panel.peakXLocal != null) {
+                    const px = panel.x + panel.peakXLocal;
+                    if (px > segL && px < segR) breakXs.push(px);
+                  }
+                  breakXs.sort((a, b) => a - b);
+
+                  // Find where clearance crosses spBotY and spTopY
+                  const botCrossings = [];
+                  const topCrossings = [];
+                  for (let k = 0; k < breakXs.length - 1; k++) {
+                    const x1 = breakXs[k], x2 = breakXs[k + 1];
+                    const c1 = clAt(x1), c2 = clAt(x2);
+                    for (const [thr, arr] of [[spBotY, botCrossings], [spTopY, topCrossings]]) {
+                      if ((c1 - thr) * (c2 - thr) < 0) {
+                        const t = (thr - c1) / (c2 - c1);
+                        arr.push(x1 + t * (x2 - x1));
+                      }
+                    }
+                  }
+
+                  // Determine visible x-range (where clearance < spBotY)
+                  let vL = segL, vR = segR;
+                  if (clAt(segL) >= spBotY) {
+                    if (botCrossings.length === 0) return null;
+                    vL = Math.min(...botCrossings);
+                  }
+                  if (clAt(segR) >= spBotY) {
+                    if (botCrossings.length === 0) return null;
+                    vR = Math.max(...botCrossings);
+                  }
+                  if (vR <= vL) return null;
+
+                  // Build polygon
+                  const pts = [];
+                  pts.push(`${s(vL)},${s(spBotY)}`);
+                  pts.push(`${s(vR)},${s(spBotY)}`);
+                  if (clAt(vR) < spBotY - 0.5) {
+                    pts.push(`${s(vR)},${s(Math.max(spTopY, clAt(vR)))}`);
+                  }
+                  const topEdgeXs = [];
+                  for (const x of topCrossings) {
+                    if (x > vL + 0.5 && x < vR - 0.5) topEdgeXs.push(x);
+                  }
+                  if (panel.peakHeight && panel.peakXLocal != null) {
+                    const px = panel.x + panel.peakXLocal;
+                    if (px > vL + 0.5 && px < vR - 0.5 && clAt(px) > spTopY) {
+                      topEdgeXs.push(px);
+                    }
+                  }
+                  topEdgeXs.sort((a, b) => b - a);
+                  for (const x of topEdgeXs) {
+                    pts.push(`${s(x)},${s(Math.max(spTopY, clAt(x)))}`);
+                  }
+                  if (clAt(vL) < spBotY - 0.5) {
+                    pts.push(`${s(vL)},${s(Math.max(spTopY, clAt(vL)))}`);
+                  }
+
+                  return pts.length >= 3 ? (
+                    <polygon
+                      key={`hspline-c${ci}-p${pi}-s${si}`}
+                      points={pts.join(' ')}
+                      fill="none"
+                      stroke={PLATE_COLOR}
+                      strokeWidth={1}
+                      strokeDasharray={DASH}
+                    />
+                  ) : null;
+                });
               });
             });
           })()}
 
-          {/* ── Course join mid-plates (multi-course walls > 3050mm) ── */}
-          {/* Rendered last so lines are visible on top of all framing detail */}
-          {isMultiCourse && courses.slice(1).map((course, i) => {
-            const joinY = yBottom - course.y;
-            // Compute x-extent where wall height >= course.y
-            const hL = heightAt ? heightAt(0) : height;
-            const hR = heightAt ? heightAt(grossLength) : height;
-            let x0, x1;
-            if (hL >= course.y && hR >= course.y) {
-              x0 = plateLeft; x1 = plateRight;
-            } else if (hL >= course.y) {
-              x0 = plateLeft;
-              x1 = Math.min(plateRight, (course.y - hL) / (hR - hL) * grossLength);
-            } else if (hR >= course.y) {
-              x0 = Math.max(plateLeft, (course.y - hL) / (hR - hL) * grossLength);
-              x1 = plateRight;
-            } else {
-              return null;
-            }
-            return (
-              <g key={`course-join-${i}`}>
-                <line
-                  x1={s(x0)} y1={s(joinY)}
-                  x2={s(x1)} y2={s(joinY)}
-                  stroke="#E74C3C" strokeWidth={1.5} strokeDasharray={DASH}
-                />
-                <line
-                  x1={s(x0)} y1={s(joinY + TOP_PLATE)}
-                  x2={s(x1)} y2={s(joinY + TOP_PLATE)}
-                  stroke="#E74C3C" strokeWidth={1} strokeDasharray={DASH}
-                />
-                <line
-                  x1={s(x0)} y1={s(joinY - TOP_PLATE)}
-                  x2={s(x1)} y2={s(joinY - TOP_PLATE)}
-                  stroke="#E74C3C" strokeWidth={1} strokeDasharray={DASH}
-                />
-                <text
-                  x={s(x1) + 6} y={s(joinY) + 4}
-                  fontSize="8" fill="#E74C3C" fontWeight="bold"
-                >
-                  Mid-plate {course.y}
-                </text>
-              </g>
-            );
-          })}
+          {/* Course join mid-plates removed — visible on External Elevation instead */}
 
         </g>
       </svg>

--- a/devpro-wall-builder/src/components/WallDrawing.jsx
+++ b/devpro-wall-builder/src/components/WallDrawing.jsx
@@ -206,21 +206,20 @@ export default function WallDrawing({ layout, wallName }) {
           {/* Course join lines (multi-course walls > 3050mm) */}
           {isMultiCourse && courses.slice(1).map((course, i) => {
             const joinY = yBottom - s(course.y);
-            // Compute x-extent where wall height >= course.y
-            const hL = heightAt ? heightAt(0) : height;
-            const hR = heightAt ? heightAt(grossLength) : height;
-            let x0, x1;
-            if (hL >= course.y && hR >= course.y) {
-              x0 = 0; x1 = grossLength;
-            } else if (hL >= course.y) {
-              x0 = 0;
-              x1 = (course.y - hL) / (hR - hL) * grossLength;
-            } else if (hR >= course.y) {
-              x0 = (course.y - hL) / (hR - hL) * grossLength;
-              x1 = grossLength;
-            } else {
-              return null;
+            // Compute x-extent where wall height >= course.y using heightAt
+            // This handles gable peaks (piecewise linear) correctly
+            if (!heightAt) return null;
+            // Sample to find where heightAt(x) crosses course.y
+            const steps = 200;
+            let x0 = null, x1 = null;
+            for (let j = 0; j <= steps; j++) {
+              const x = (j / steps) * grossLength;
+              if (heightAt(x) >= course.y) {
+                if (x0 === null) x0 = x;
+                x1 = x;
+              }
             }
+            if (x0 === null) return null;
             return (
               <g key={`course-join-${i}`}>
                 <line

--- a/devpro-wall-builder/src/components/WallForm.jsx
+++ b/devpro-wall-builder/src/components/WallForm.jsx
@@ -8,6 +8,7 @@ const defaultOpening = {
   height_mm: 1200,
   sill_mm: 900,
   position_from_left_mm: 1000,
+  lintel_height_mm: 200,
 };
 
 const defaultWall = {
@@ -296,6 +297,16 @@ export default function WallForm({ onCalculate, onChange, initialWall }) {
                 type="number"
                 value={op.position_from_left_mm}
                 onChange={e => updateOpening(i, 'position_from_left_mm', parseInt(e.target.value) || 0)}
+                style={styles.input}
+                min={0}
+              />
+            </div>
+            <div style={styles.field}>
+              <label style={styles.label}>Lintel Height (mm)</label>
+              <input
+                type="number"
+                value={op.lintel_height_mm ?? 200}
+                onChange={e => updateOpening(i, 'lintel_height_mm', parseInt(e.target.value) || 0)}
                 style={styles.input}
                 min={0}
               />

--- a/devpro-wall-builder/src/utils/calculator.js
+++ b/devpro-wall-builder/src/utils/calculator.js
@@ -190,6 +190,7 @@ export function calculateWallLayout(wall) {
       heightRight: lHeightRight,
       peakHeight: lPeakHeight,
       peakXLocal: lPeakXLocal,
+      beamHeight: opening.lintel_height_mm ?? 200,
       type: 'lintel',
     });
   }

--- a/devpro-wall-builder/src/utils/magboardOptimizer.js
+++ b/devpro-wall-builder/src/utils/magboardOptimizer.js
@@ -64,16 +64,20 @@ export function extractMagboardPieces(layout, wallName = '') {
     }
   }
 
-  // ── Lintels: 2 magboard pieces each ──
+  // ── Lintels: 2 magboard pieces each (EPS area above timber beam) ──
   for (const lintel of lintels) {
-    for (let i = 0; i < 2; i++) {
-      cutPieces.push({
-        width: lintel.width,
-        height: lintel.height,
-        type: 'lintel',
-        label: `${lintel.ref} Lintel`,
-        wallName,
-      });
+    const beamH = lintel.beamHeight || 200;
+    const epsHeight = lintel.height - beamH;
+    if (epsHeight > 0) {
+      for (let i = 0; i < 2; i++) {
+        cutPieces.push({
+          width: lintel.width,
+          height: epsHeight,
+          type: 'lintel',
+          label: `${lintel.ref} Lintel`,
+          wallName,
+        });
+      }
     }
   }
 
@@ -157,7 +161,7 @@ export function extractMagboardPieces(layout, wallName = '') {
           rightEdge = panel.x + panel.width - BOTTOM_PLATE;
         }
 
-        // Split around lintels (10mm clearance from lintel edges)
+        // Split around lintels, openings, opening plates & splines
         const splineLeft = leftEdge + HSPLINE_CLEARANCE;
         const splineRight = rightEdge - HSPLINE_CLEARANCE;
         if (splineRight > splineLeft) {
@@ -165,6 +169,14 @@ export function extractMagboardPieces(layout, wallName = '') {
           for (const l of lintels) {
             const eL = Math.max(l.x - HSPLINE_CLEARANCE, splineLeft);
             const eR = Math.min(l.x + l.width + HSPLINE_CLEARANCE, splineRight);
+            if (eL < eR) excl.push([eL, eR]);
+          }
+          for (const op of openings) {
+            const hasSill = op.y > 0;
+            const oL = op.x - BOTTOM_PLATE - (hasSill ? SPLINE_WIDTH : 0) - HSPLINE_CLEARANCE;
+            const oR = op.x + op.drawWidth + BOTTOM_PLATE + (hasSill ? SPLINE_WIDTH : 0) + HSPLINE_CLEARANCE;
+            const eL = Math.max(oL, splineLeft);
+            const eR = Math.min(oR, splineRight);
             if (eL < eR) excl.push([eL, eR]);
           }
           excl.sort((a, b) => a[0] - b[0]);


### PR DESCRIPTION
## Summary
- Configurable lintel timber beam height (default 200mm) with EPS fill above, inset 10mm from vertical spline inner edges
- Framing elevation now matches EPS elevation: vertical/horizontal splines follow raked/gable angles, opening splines use polygon rendering, horizontal splines have opening/lintel exclusions with BOTTOM_PLATE inset
- Lintel timber beam rect shown on both EPS and framing elevations
- Removed red course join lines from EPS and framing elevations — course boundary now only shown on External Elevation view
- Fixed course join line for gable walls on External Elevation (was missing due to linear interpolation not handling gable peaks)

## Test plan
- [x] 20 unit tests passing
- [x] Build succeeds
- [ ] Visual: standard multi-course wall — no red lines on EPS/framing, course line on external elevation
- [ ] Visual: raked multi-course wall — splines follow angle, course line clips correctly
- [ ] Visual: gable multi-course wall — splines follow angle, course line visible
- [ ] Visual: wall with window — lintel beam + EPS gap, opening splines angled on raked/gable

🤖 Generated with [Claude Code](https://claude.com/claude-code)