### PR TITLE
Add wall snapping system for flexible floor plan layouts

### DIFF
--- a/devpro-wall-builder/src/components/ModelViewer3D.jsx
+++ b/devpro-wall-builder/src/components/ModelViewer3D.jsx
@@ -1,47 +1,88 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { Canvas } from '@react-three/fiber';
-import { OrbitControls, PerspectiveCamera, Grid, Text } from '@react-three/drei';
-import { computeFloorPlan } from '../utils/floorPlan.js';
+import { OrbitControls, PerspectiveCamera, Grid, Text, Sphere } from '@react-three/drei';
+import { computeFloorPlanFromConnections } from '../utils/floorPlan.js';
 import { calculateWallLayout } from '../utils/calculator.js';
+import { computeLayoutBounds, computeWallEndpoint } from '../utils/wallSnap.js';
 import { WALL_THICKNESS, COLORS } from '../utils/constants.js';
 
-const MM_TO_M = 1 / 1000; // Convert mm to meters for Three.js scene
+const MM_TO_M = 1 / 1000;
+
+const WALL_COLORS = {
+  front: COLORS.PANEL,
+  right: '#5BA55B',
+  back: '#D9904A',
+  left: COLORS.END_CAP,
+};
+const SELECTED_EMISSIVE = '#335599';
+const SNAP_POINT_COLOR = '#ff4444';
+const SNAP_POINT_CONNECTED_COLOR = '#44cc44';
+
+/**
+ * Small sphere marker at a wall's snap endpoint.
+ */
+function SnapPointMarker({ entry, end, isConnected, onClick }) {
+  const s = MM_TO_M;
+  const endpoint = computeWallEndpoint(entry.wall, end);
+  const angle = entry.rotation.y;
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+
+  // Position in world space
+  const wx = entry.position.x + endpoint.localX_mm * cos;
+  const wz = entry.position.z - endpoint.localX_mm * sin;
+  const wy = 0.15; // slightly above ground
+
+  const color = isConnected ? SNAP_POINT_CONNECTED_COLOR : SNAP_POINT_COLOR;
+
+  return (
+    <Sphere
+      args={[0.12, 16, 16]}
+      position={[wx * s, wy, wz * s]}
+      onClick={(e) => { e.stopPropagation(); onClick(end); }}
+    >
+      <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.5} />
+    </Sphere>
+  );
+}
 
 /**
  * Single wall mesh — a box with openings cut out (approximated as separate meshes).
  */
-function WallMesh({ entry, layout }) {
+function WallMesh({ entry, layout, isSelected, onSelect, showWireframe }) {
   const { position, rotation, dimensions } = entry;
   const s = MM_TO_M;
   const len = dimensions.length * s;
   const h = dimensions.height * s;
   const thick = dimensions.thickness * s;
 
-  // Wall color by side
-  const colorMap = {
-    front: '#4A90D9',
-    right: '#5BA55B',
-    back: '#D9904A',
-    left: '#9B59B6',
-  };
-  const wallColor = colorMap[entry.side] || '#4A90D9';
+  const wallColor = WALL_COLORS[entry.side] || COLORS.PANEL;
 
   return (
     <group
       position={[position.x * s, position.y * s, position.z * s]}
       rotation={[rotation.x, rotation.y, rotation.z]}
+      onClick={(e) => { e.stopPropagation(); onSelect(entry.wall.id); }}
     >
       {/* Main wall body */}
-      <mesh>
+      <mesh castShadow>
         <boxGeometry args={[len, h, thick]} />
-        <meshStandardMaterial color={wallColor} transparent opacity={0.7} />
+        <meshStandardMaterial
+          color={wallColor}
+          transparent
+          opacity={isSelected ? 0.85 : 0.7}
+          emissive={isSelected ? SELECTED_EMISSIVE : '#000000'}
+          emissiveIntensity={isSelected ? 0.3 : 0}
+        />
       </mesh>
 
       {/* Wall wireframe outline */}
-      <mesh>
-        <boxGeometry args={[len, h, thick]} />
-        <meshBasicMaterial color="#333" wireframe />
-      </mesh>
+      {showWireframe && (
+        <mesh>
+          <boxGeometry args={[len, h, thick]} />
+          <meshBasicMaterial color="#333" wireframe />
+        </mesh>
+      )}
 
       {/* Openings rendered as darker inset boxes */}
       {layout?.openings?.map((op, i) => {
@@ -70,12 +111,12 @@ function WallMesh({ entry, layout }) {
 }
 
 /**
- * Floor plane showing the rectangular footprint.
+ * Floor plane showing the footprint.
  */
 function FloorPlane({ width, depth }) {
   const s = MM_TO_M;
   return (
-    <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0, 0]}>
+    <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0, 0]} receiveShadow>
       <planeGeometry args={[width * s + 1, depth * s + 1]} />
       <meshStandardMaterial color="#e8e8e0" transparent opacity={0.5} />
     </mesh>
@@ -83,31 +124,185 @@ function FloorPlane({ width, depth }) {
 }
 
 /**
- * 3D Model Viewer for a project's walls arranged in a rectangular floor plan.
- *
- * @param {{ walls: Array }} props - Array of wall input objects from the project
+ * Snap controls panel (HTML overlay).
  */
-export default function ModelViewer3D({ walls }) {
-  const [showWireframe, setShowWireframe] = useState(false);
+function SnapControlsPanel({
+  selectedWall, selectedEnd, walls, connections, onAttach, onDetach, onClose,
+}) {
+  const [attachWallId, setAttachWallId] = useState('');
+  const [attachEnd, setAttachEnd] = useState('left');
+  const [angleDeg, setAngleDeg] = useState(90);
 
-  const floorPlan = useMemo(() => computeFloorPlan(walls), [walls]);
+  // Find existing connection for this endpoint
+  const existingConn = connections.find(
+    c => (c.wallId === selectedWall.id && c.anchorEnd === selectedEnd) ||
+         (c.attachedWallId === selectedWall.id && c.attachedEnd === selectedEnd)
+  );
+
+  // Available walls (exclude self and already-connected-at-this-endpoint walls)
+  const availableWalls = walls.filter(w => w.id !== selectedWall.id);
+
+  const handleAttach = () => {
+    if (!attachWallId) return;
+    onAttach({
+      id: crypto.randomUUID(),
+      wallId: selectedWall.id,
+      anchorEnd: selectedEnd,
+      attachedWallId: attachWallId,
+      attachedEnd: attachEnd,
+      angleDeg,
+    });
+  };
+
+  return (
+    <div style={styles.snapPanel}>
+      <div style={styles.snapHeader}>
+        <strong>{selectedWall.name} — {selectedEnd} end</strong>
+        <button onClick={onClose} style={styles.snapCloseBtn}>X</button>
+      </div>
+
+      {existingConn ? (
+        <div style={styles.snapBody}>
+          <p style={styles.snapText}>
+            Connected to: {walls.find(w =>
+              w.id === (existingConn.wallId === selectedWall.id
+                ? existingConn.attachedWallId
+                : existingConn.wallId)
+            )?.name || 'Unknown'}
+          </p>
+          <button
+            onClick={() => onDetach(existingConn.id)}
+            style={styles.snapDetachBtn}
+          >
+            Detach
+          </button>
+        </div>
+      ) : (
+        <div style={styles.snapBody}>
+          <label style={styles.snapLabel}>
+            Attach wall:
+            <select
+              value={attachWallId}
+              onChange={e => setAttachWallId(e.target.value)}
+              style={styles.snapSelect}
+            >
+              <option value="">Select wall...</option>
+              {availableWalls.map(w => (
+                <option key={w.id} value={w.id}>{w.name}</option>
+              ))}
+            </select>
+          </label>
+
+          <label style={styles.snapLabel}>
+            Connect using its:
+            <select
+              value={attachEnd}
+              onChange={e => setAttachEnd(e.target.value)}
+              style={styles.snapSelect}
+            >
+              <option value="left">Left end</option>
+              <option value="right">Right end</option>
+            </select>
+          </label>
+
+          <div style={styles.snapLabel}>
+            Orientation:
+            <div style={styles.angleGroup}>
+              {[0, 90, 180, 270].map(a => (
+                <button
+                  key={a}
+                  onClick={() => setAngleDeg(a)}
+                  style={{
+                    ...styles.angleBtn,
+                    ...(angleDeg === a ? styles.angleBtnActive : {}),
+                  }}
+                >
+                  {a}°
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <button
+            onClick={handleAttach}
+            disabled={!attachWallId}
+            style={{
+              ...styles.snapAttachBtn,
+              opacity: attachWallId ? 1 : 0.5,
+            }}
+          >
+            Attach
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * 3D Model Viewer for a project's walls arranged via snap connections.
+ */
+export default function ModelViewer3D({ walls, connections = [], onConnectionsChange }) {
+  const [showWireframe, setShowWireframe] = useState(false);
+  const [selectedWallId, setSelectedWallId] = useState(null);
+  const [selectedEnd, setSelectedEnd] = useState(null);
+
+  const floorPlan = useMemo(
+    () => computeFloorPlanFromConnections(walls, connections),
+    [walls, connections]
+  );
 
   const layouts = useMemo(() => {
     const map = {};
     for (const entry of floorPlan) {
-      map[entry.side] = calculateWallLayout(entry.wall);
+      const key = entry.wall.id || entry.side;
+      map[key] = calculateWallLayout(entry.wall);
     }
     return map;
   }, [floorPlan]);
 
-  // Compute scene bounds for camera
   const sceneBounds = useMemo(() => {
-    if (!walls || walls.length === 0) return { width: 5000, depth: 5000, maxH: 3000 };
-    const width = walls[0]?.length_mm || 5000;
-    const depth = walls[1]?.length_mm || width;
-    const maxH = Math.max(...walls.map(w => w.height_mm || 2700));
-    return { width, depth, maxH };
-  }, [walls]);
+    if (!floorPlan || floorPlan.length === 0) return { width: 5000, depth: 5000, maxHeight: 3000 };
+    const bounds = computeLayoutBounds(floorPlan);
+    return {
+      width: Math.max(bounds.width, 2000),
+      depth: Math.max(bounds.depth, 2000),
+      maxHeight: Math.max(bounds.maxHeight, 2000),
+    };
+  }, [floorPlan]);
+
+  const selectedWall = walls.find(w => w.id === selectedWallId);
+  const selectedEntry = floorPlan.find(e => e.wall.id === selectedWallId);
+
+  const handleSelectWall = useCallback((wallId) => {
+    setSelectedWallId(prev => prev === wallId ? null : wallId);
+    setSelectedEnd(null);
+  }, []);
+
+  const handleSelectEnd = useCallback((end) => {
+    setSelectedEnd(prev => prev === end ? null : end);
+  }, []);
+
+  const isEndpointConnected = useCallback((wallId, end) => {
+    return connections.some(
+      c => (c.wallId === wallId && c.anchorEnd === end) ||
+           (c.attachedWallId === wallId && c.attachedEnd === end)
+    );
+  }, [connections]);
+
+  const handleAttach = useCallback((connection) => {
+    if (onConnectionsChange) {
+      onConnectionsChange([...connections, connection]);
+    }
+    setSelectedEnd(null);
+  }, [connections, onConnectionsChange]);
+
+  const handleDetach = useCallback((connectionId) => {
+    if (onConnectionsChange) {
+      onConnectionsChange(connections.filter(c => c.id !== connectionId));
+    }
+    setSelectedEnd(null);
+  }, [connections, onConnectionsChange]);
 
   if (!walls || walls.length === 0) {
     return (
@@ -117,23 +312,30 @@ export default function ModelViewer3D({ walls }) {
     );
   }
 
-  const camDist = Math.max(sceneBounds.width, sceneBounds.depth, sceneBounds.maxH) * MM_TO_M * 1.5;
+  const camDist = Math.max(sceneBounds.width, sceneBounds.depth, sceneBounds.maxHeight) * MM_TO_M * 1.5;
 
   return (
     <div style={styles.container}>
       <div style={styles.header}>
         <h3 style={styles.title}>3D Model Viewer</h3>
-        <label style={styles.toggle}>
-          <input
-            type="checkbox"
-            checked={showWireframe}
-            onChange={e => setShowWireframe(e.target.checked)}
-          />
-          Wireframe
-        </label>
+        <div style={styles.headerControls}>
+          {selectedWall && (
+            <span style={styles.selectedLabel}>
+              Selected: {selectedWall.name}
+            </span>
+          )}
+          <label style={styles.toggle}>
+            <input
+              type="checkbox"
+              checked={showWireframe}
+              onChange={e => setShowWireframe(e.target.checked)}
+            />
+            Wireframe
+          </label>
+        </div>
       </div>
       <div style={styles.canvasWrap}>
-        <Canvas shadows>
+        <Canvas shadows onClick={() => { setSelectedWallId(null); setSelectedEnd(null); }}>
           <PerspectiveCamera
             makeDefault
             position={[camDist * 0.8, camDist * 0.6, camDist * 0.8]}
@@ -161,23 +363,54 @@ export default function ModelViewer3D({ walls }) {
           />
 
           {/* Walls */}
-          {floorPlan.map((entry, i) => (
+          {floorPlan.map((entry) => (
             <WallMesh
-              key={`wall-${i}`}
+              key={`wall-${entry.wall.id}`}
               entry={entry}
-              layout={layouts[entry.side]}
+              layout={layouts[entry.wall.id] || layouts[entry.side]}
+              isSelected={entry.wall.id === selectedWallId}
+              onSelect={handleSelectWall}
+              showWireframe={showWireframe}
             />
           ))}
+
+          {/* Snap point markers for selected wall */}
+          {selectedEntry && (
+            <>
+              <SnapPointMarker
+                entry={selectedEntry}
+                end="left"
+                isConnected={isEndpointConnected(selectedWallId, 'left')}
+                onClick={handleSelectEnd}
+              />
+              <SnapPointMarker
+                entry={selectedEntry}
+                end="right"
+                isConnected={isEndpointConnected(selectedWallId, 'right')}
+                onClick={handleSelectEnd}
+              />
+            </>
+          )}
 
           {/* Axes helper */}
           <axesHelper args={[2]} />
         </Canvas>
+
+        {/* Snap controls overlay */}
+        {selectedWall && selectedEnd && onConnectionsChange && (
+          <SnapControlsPanel
+            selectedWall={selectedWall}
+            selectedEnd={selectedEnd}
+            walls={walls}
+            connections={connections}
+            onAttach={handleAttach}
+            onDetach={handleDetach}
+            onClose={() => setSelectedEnd(null)}
+          />
+        )}
       </div>
       <div style={styles.legend}>
-        <span style={{ ...styles.legendItem, borderLeft: '4px solid #4A90D9' }}>Front</span>
-        <span style={{ ...styles.legendItem, borderLeft: '4px solid #5BA55B' }}>Right</span>
-        <span style={{ ...styles.legendItem, borderLeft: '4px solid #D9904A' }}>Back</span>
-        <span style={{ ...styles.legendItem, borderLeft: '4px solid #9B59B6' }}>Left</span>
+        <span style={styles.legendHint}>Click a wall to select it. Click the red markers to snap another wall.</span>
       </div>
     </div>
   );
@@ -198,6 +431,16 @@ const styles = {
     padding: '12px 20px',
     borderBottom: '1px solid #eee',
   },
+  headerControls: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 16,
+  },
+  selectedLabel: {
+    fontSize: 13,
+    color: '#2C5F8A',
+    fontWeight: 600,
+  },
   title: {
     margin: 0,
     fontSize: 16,
@@ -216,6 +459,7 @@ const styles = {
     width: '100%',
     height: 500,
     background: '#f5f5f0',
+    position: 'relative',
   },
   legend: {
     display: 'flex',
@@ -223,15 +467,108 @@ const styles = {
     padding: '10px 20px',
     borderTop: '1px solid #eee',
   },
-  legendItem: {
+  legendHint: {
     fontSize: 12,
-    color: '#555',
-    paddingLeft: 8,
+    color: '#888',
   },
   empty: {
     padding: '40px 20px',
     textAlign: 'center',
     color: '#999',
     fontSize: 14,
+  },
+
+  // Snap controls panel
+  snapPanel: {
+    position: 'absolute',
+    top: 10,
+    right: 10,
+    background: '#fff',
+    border: '1px solid #ddd',
+    borderRadius: 8,
+    boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+    width: 260,
+    zIndex: 10,
+  },
+  snapHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '10px 14px',
+    borderBottom: '1px solid #eee',
+    fontSize: 13,
+  },
+  snapCloseBtn: {
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: 14,
+    color: '#999',
+    padding: '2px 6px',
+  },
+  snapBody: {
+    padding: '12px 14px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 10,
+  },
+  snapText: {
+    margin: 0,
+    fontSize: 13,
+    color: '#555',
+  },
+  snapLabel: {
+    fontSize: 12,
+    color: '#555',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 4,
+  },
+  snapSelect: {
+    padding: '6px 8px',
+    borderRadius: 4,
+    border: '1px solid #ddd',
+    fontSize: 13,
+  },
+  angleGroup: {
+    display: 'flex',
+    gap: 4,
+    marginTop: 4,
+  },
+  angleBtn: {
+    flex: 1,
+    padding: '6px 0',
+    border: '1px solid #ddd',
+    borderRadius: 4,
+    background: '#f8f9fa',
+    cursor: 'pointer',
+    fontSize: 12,
+    fontWeight: 500,
+    color: '#555',
+  },
+  angleBtnActive: {
+    background: '#2C5F8A',
+    color: '#fff',
+    borderColor: '#2C5F8A',
+  },
+  snapAttachBtn: {
+    padding: '8px 0',
+    background: '#2C5F8A',
+    color: '#fff',
+    border: 'none',
+    borderRadius: 4,
+    cursor: 'pointer',
+    fontSize: 13,
+    fontWeight: 600,
+  },
+  snapDetachBtn: {
+    padding: '8px 0',
+    background: '#e74c3c',
+    color: '#fff',
+    border: 'none',
+    borderRadius: 4,
+    cursor: 'pointer',
+    fontSize: 13,
+    fontWeight: 600,
   },
 };

--- a/devpro-wall-builder/src/pages/ProjectPage.jsx
+++ b/devpro-wall-builder/src/pages/ProjectPage.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
   getProjects, getProjectWalls, deleteWall, renameProject,
-  copyWallToProject,
+  copyWallToProject, getProjectConnections, saveProjectConnections,
 } from '../utils/storage.js';
 import EpsBlockSummary from '../components/EpsBlockSummary.jsx';
 import MagboardSheetSummary from '../components/MagboardSheetSummary.jsx';
@@ -17,6 +17,7 @@ export default function ProjectPage() {
   const [renamingProject, setRenamingProject] = useState(false);
   const [renameValue, setRenameValue] = useState('');
   const [copyingWallId, setCopyingWallId] = useState(null);
+  const [connections, setConnections] = useState([]);
 
   useEffect(() => {
     const projects = getProjects();
@@ -27,12 +28,19 @@ export default function ProjectPage() {
     }
     setProject(p);
     setWalls(getProjectWalls(projectId));
+    setConnections(getProjectConnections(projectId));
   }, [projectId, navigate]);
 
   const refresh = () => {
     setWalls(getProjectWalls(projectId));
+    setConnections(getProjectConnections(projectId));
     const p = getProjects().find(p => p.id === projectId);
     if (p) setProject(p);
+  };
+
+  const handleConnectionsChange = (newConnections) => {
+    saveProjectConnections(projectId, newConnections);
+    setConnections(newConnections);
   };
 
   const handleDeleteWall = (wallId, e) => {
@@ -102,7 +110,13 @@ export default function ProjectPage() {
         </div>
 
         {/* 3D Model Viewer */}
-        {walls.length > 0 && <ModelViewer3D walls={walls} />}
+        {walls.length > 0 && (
+          <ModelViewer3D
+            walls={walls}
+            connections={connections}
+            onConnectionsChange={handleConnectionsChange}
+          />
+        )}
 
         {/* Material Summaries */}
         {walls.length > 0 && <EpsBlockSummary walls={walls} />}

--- a/devpro-wall-builder/src/utils/calculator.js
+++ b/devpro-wall-builder/src/utils/calculator.js
@@ -173,7 +173,7 @@ export function calculateWallLayout(wall) {
     // Detect gable peak within lintel span
     let lPeakHeight, lPeakXLocal;
     if (profile === WALL_PROFILES.GABLE) {
-      const peakX = wall.peak_position_mm ?? Math.round(grossLen / 2);
+      const peakX = wall.peak_position_mm ?? Math.round(grossLength / 2);
       if (lintelLeft < peakX && lintelRight > peakX) {
         lPeakHeight = Math.max(0, heightAt(peakX) - openTop);
         lPeakXLocal = peakX - lintelLeft;
@@ -405,7 +405,7 @@ export function calculateWallLayout(wall) {
   // For gable walls, detect panels that straddle the peak and stamp them
   // with peakHeight and peakXLocal so profile renderers can draw a pentagon.
   if (profile === WALL_PROFILES.GABLE) {
-    const peakX = wall.peak_position_mm ?? Math.round(grossLen / 2);
+    const peakX = wall.peak_position_mm ?? Math.round(grossLength / 2);
     panels.forEach(panel => {
       const panelRight = panel.x + panel.width;
       if (panel.x < peakX && panelRight > peakX) {

--- a/devpro-wall-builder/src/utils/floorPlan.js
+++ b/devpro-wall-builder/src/utils/floorPlan.js
@@ -29,6 +29,7 @@
  */
 
 import { WALL_THICKNESS } from './constants.js';
+import { resolveFloorPlanLayout, computeLayoutBounds } from './wallSnap.js';
 
 /**
  * Compute the 3D position and rotation for each wall in a rectangular floor plan.
@@ -154,6 +155,21 @@ export function computeFloorPlanCorners(walls) {
  * @param {Array} floorPlanEntries - Output of computeFloorPlan()
  * @returns {Array<{corner: string, endA: {x,z}, endB: {x,z}, gap_mm: number}>}
  */
+/**
+ * Compute floor plan layout from walls and snap connections.
+ * Falls back to the rectangular computeFloorPlan when no connections exist.
+ *
+ * @param {Array} walls - All wall objects in the project
+ * @param {Array} connections - Snap connection objects (may be empty/null)
+ * @returns {Array} Same shape as computeFloorPlan output
+ */
+export function computeFloorPlanFromConnections(walls, connections) {
+  if (!connections || connections.length === 0) {
+    return computeFloorPlan(walls);
+  }
+  return resolveFloorPlanLayout(walls, connections);
+}
+
 export function validateCornerJoins(floorPlanEntries) {
   if (floorPlanEntries.length < 2) return [];
 

--- a/devpro-wall-builder/src/utils/storage.js
+++ b/devpro-wall-builder/src/utils/storage.js
@@ -5,6 +5,10 @@ function projectWallsKey(projectId) {
   return `devpro-project-${projectId}`;
 }
 
+function projectConnectionsKey(projectId) {
+  return `devpro-project-${projectId}-connections`;
+}
+
 function readJson(key) {
   try {
     const raw = localStorage.getItem(key);
@@ -99,6 +103,10 @@ export function saveWall(projectId, wallInput) {
 export function deleteWall(projectId, wallId) {
   const walls = getProjectWalls(projectId).filter(w => w.id !== wallId);
   localStorage.setItem(projectWallsKey(projectId), JSON.stringify(walls));
+  // Remove any connections referencing the deleted wall
+  const connections = getProjectConnections(projectId)
+    .filter(c => c.wallId !== wallId && c.attachedWallId !== wallId);
+  saveProjectConnections(projectId, connections);
   syncWallCount(projectId);
 }
 
@@ -116,6 +124,16 @@ export function copyWallToProject(wall, targetProjectId) {
   return copy;
 }
 
+// ── Connections (wall snap layout) ──
+
+export function getProjectConnections(projectId) {
+  return readJson(projectConnectionsKey(projectId)) || [];
+}
+
+export function saveProjectConnections(projectId, connections) {
+  localStorage.setItem(projectConnectionsKey(projectId), JSON.stringify(connections));
+}
+
 // ── Archive (export/import as JSON zip) ──
 
 export async function exportProject(projectId) {
@@ -125,9 +143,11 @@ export async function exportProject(projectId) {
   if (!project) throw new Error('Project not found');
 
   const walls = getProjectWalls(projectId);
+  const connections = getProjectConnections(projectId);
   const zip = new JSZip();
   zip.file('project.json', JSON.stringify({ ...project, exportedAt: Date.now() }, null, 2));
   zip.file('walls.json', JSON.stringify(walls, null, 2));
+  zip.file('connections.json', JSON.stringify(connections, null, 2));
 
   const blob = await zip.generateAsync({ type: 'blob' });
   const url = URL.createObjectURL(blob);
@@ -159,16 +179,31 @@ export async function importProject(file) {
     wallCount: wallsData.length,
   };
 
-  // Assign fresh wall IDs too
-  const walls = wallsData.map(w => ({
-    ...w,
+  // Import connections if present (backward compatible with older exports)
+  const connectionsJson = await zip.file('connections.json')?.async('string');
+  const connectionsData = connectionsJson ? JSON.parse(connectionsJson) : [];
+
+  // Remap wall IDs in connections
+  const wallIdMap = new Map();
+  const walls = wallsData.map(w => {
+    const newWallId = crypto.randomUUID();
+    wallIdMap.set(w.id, newWallId);
+    return { ...w, id: newWallId };
+  });
+  const connections = connectionsData.map(c => ({
+    ...c,
     id: crypto.randomUUID(),
+    wallId: wallIdMap.get(c.wallId) || c.wallId,
+    attachedWallId: wallIdMap.get(c.attachedWallId) || c.attachedWallId,
   }));
 
   const projects = getProjects();
   projects.push(project);
   saveProjects(projects);
   localStorage.setItem(projectWallsKey(newId), JSON.stringify(walls));
+  if (connections.length > 0) {
+    saveProjectConnections(newId, connections);
+  }
 
   return project;
 }

--- a/devpro-wall-builder/src/utils/wallSnap.js
+++ b/devpro-wall-builder/src/utils/wallSnap.js
@@ -1,0 +1,386 @@
+/**
+ * Wall Snap Geometry Engine
+ *
+ * Computes wall positions in a floor plan based on snap connections.
+ * Each wall runs along its local X axis. The "left" end is at x=0,
+ * the "right" end is at x=length_mm (before deductions).
+ *
+ * Snap points account for deductions:
+ *   left snap point  = deduction_left_mm   from the geometric left edge
+ *   right snap point = length_mm - deduction_right_mm  from the geometric left edge
+ *
+ * Walls are placed in the XZ plane. Y is height (each wall centered on its own height).
+ */
+
+import { WALL_THICKNESS } from './constants.js';
+
+/**
+ * Get the snap point of a wall end in the wall's local coordinate space.
+ * The wall runs along local X from 0 to length_mm, centered at length_mm/2.
+ *
+ * Returns offset from wall center (which is what Three.js positions use).
+ *
+ * @param {Object} wall - Wall object with length_mm, deduction_left_mm, deduction_right_mm
+ * @param {"left"|"right"} end - Which end
+ * @returns {{ localX_mm: number }} Offset from wall center along local X
+ */
+export function computeWallEndpoint(wall, end) {
+  const halfLen = wall.length_mm / 2;
+  const dedLeft = wall.deduction_left_mm || 0;
+  const dedRight = wall.deduction_right_mm || 0;
+
+  if (end === 'left') {
+    // Left snap point: inset by deduction from the left edge
+    // In center-origin coords: -halfLen + dedLeft
+    return { localX_mm: -halfLen + dedLeft };
+  }
+  // Right snap point: inset by deduction from the right edge
+  // In center-origin coords: halfLen - dedRight
+  return { localX_mm: halfLen - dedRight };
+}
+
+/**
+ * Compute the world-space position and rotation for an attached wall,
+ * given an anchor wall's placement and a connection definition.
+ *
+ * @param {Object} anchorWall - The wall being snapped TO
+ * @param {"left"|"right"} anchorEnd - Which end of the anchor wall
+ * @param {{ x: number, y: number, z: number }} anchorPos - Anchor wall center position (mm)
+ * @param {number} anchorAngleRad - Anchor wall's Y rotation in radians
+ * @param {Object} attachedWall - The wall being attached
+ * @param {"left"|"right"} attachedEnd - Which end of the attached wall connects
+ * @param {number} angleDeg - Rotation of attached wall relative to anchor (0, 90, 180, 270)
+ * @returns {{ position: {x: number, y: number, z: number}, rotation: {x: number, y: number, z: number} }}
+ */
+export function computeSnapPosition(
+  anchorWall, anchorEnd, anchorPos, anchorAngleRad,
+  attachedWall, attachedEnd, angleDeg
+) {
+  const t = WALL_THICKNESS;
+
+  // 1. Find anchor's snap point in world space
+  const anchorEndpoint = computeWallEndpoint(anchorWall, anchorEnd);
+  const anchorCos = Math.cos(anchorAngleRad);
+  const anchorSin = Math.sin(anchorAngleRad);
+
+  // Anchor snap point in world space (XZ plane)
+  const snapX = anchorPos.x + anchorEndpoint.localX_mm * anchorCos;
+  const snapZ = anchorPos.z - anchorEndpoint.localX_mm * anchorSin;
+
+  // 2. Compute the attached wall's world rotation
+  const angleRad = (angleDeg * Math.PI) / 180;
+  const attachedAngleRad = anchorAngleRad + angleRad;
+
+  // 3. Find the attached wall's endpoint offset (we need to position the wall
+  //    so that its specified end lands on the snap point)
+  const attachedEndpoint = computeWallEndpoint(attachedWall, attachedEnd);
+  const attachedCos = Math.cos(attachedAngleRad);
+  const attachedSin = Math.sin(attachedAngleRad);
+
+  // The attached wall's center needs to be offset so its endpoint hits the snap point
+  const centerX = snapX - attachedEndpoint.localX_mm * attachedCos;
+  const centerZ = snapZ + attachedEndpoint.localX_mm * attachedSin;
+
+  // 4. Apply wall thickness offset perpendicular to the anchor wall's face
+  //    so walls butt against each other rather than overlapping
+  // The perpendicular direction to the anchor wall is along its local Z axis
+  // (90° rotated from its facing direction)
+  const perpX = anchorSin;  // sin(angle) gives the X component of the perpendicular
+  const perpZ = anchorCos;  // cos(angle) gives the Z component of the perpendicular
+
+  // Offset by half thickness of each wall
+  // Direction depends on which side: for 90° snap, offset outward
+  // For 0°/180° (inline), no perpendicular offset needed
+  let offsetX = 0;
+  let offsetZ = 0;
+  const normalizedAngle = ((angleDeg % 360) + 360) % 360;
+  if (normalizedAngle === 90) {
+    offsetX = perpX * (t / 2);
+    offsetZ = perpZ * (t / 2);
+  } else if (normalizedAngle === 270) {
+    offsetX = -perpX * (t / 2);
+    offsetZ = -perpZ * (t / 2);
+  }
+
+  // 5. Y position: each wall centered on its own height
+  const posY = attachedWall.height_mm / 2;
+
+  return {
+    position: {
+      x: centerX + offsetX,
+      y: posY,
+      z: centerZ + offsetZ,
+    },
+    rotation: {
+      x: 0,
+      y: attachedAngleRad,
+      z: 0,
+    },
+  };
+}
+
+/**
+ * Resolve full floor plan layout from walls and their snap connections.
+ *
+ * Builds a graph of connections and traverses it BFS-style from a root wall.
+ * Walls with no connections are placed at origin as standalone.
+ *
+ * @param {Array} walls - All wall objects in the project
+ * @param {Array} connections - Array of connection objects
+ * @returns {Array<{ wall, side: string, position: {x,y,z}, rotation: {x,y,z}, dimensions: {length, height, thickness} }>}
+ */
+export function resolveFloorPlanLayout(walls, connections) {
+  if (!walls || walls.length === 0) return [];
+  if (!connections || connections.length === 0) {
+    // No connections: place each wall at origin (backward compat)
+    return walls.map((wall, i) => ({
+      wall,
+      side: i === 0 ? 'front' : `wall-${i}`,
+      position: { x: 0, y: wall.height_mm / 2, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      dimensions: { length: wall.length_mm, height: wall.height_mm, thickness: WALL_THICKNESS },
+    }));
+  }
+
+  const wallMap = new Map(walls.map(w => [w.id, w]));
+
+  // Build adjacency: for each wall, which connections reference it?
+  const adjacency = new Map();
+  for (const wall of walls) {
+    adjacency.set(wall.id, []);
+  }
+  for (const conn of connections) {
+    if (adjacency.has(conn.wallId)) {
+      adjacency.get(conn.wallId).push(conn);
+    }
+    if (adjacency.has(conn.attachedWallId)) {
+      adjacency.get(conn.attachedWallId).push(conn);
+    }
+  }
+
+  // Find root wall: a wall that appears as an anchor but never as an attached wall,
+  // or just the first wall if all are attached
+  const attachedIds = new Set(connections.map(c => c.attachedWallId));
+  const rootWall = walls.find(w => !attachedIds.has(w.id)) || walls[0];
+
+  // BFS to place walls
+  const placed = new Map(); // wallId → { position, rotation }
+  const results = [];
+
+  // Place root at origin
+  placed.set(rootWall.id, {
+    position: { x: 0, y: rootWall.height_mm / 2, z: 0 },
+    rotation: { x: 0, y: 0, z: 0 },
+  });
+  results.push({
+    wall: rootWall,
+    side: 'root',
+    position: { x: 0, y: rootWall.height_mm / 2, z: 0 },
+    rotation: { x: 0, y: 0, z: 0 },
+    dimensions: { length: rootWall.length_mm, height: rootWall.height_mm, thickness: WALL_THICKNESS },
+  });
+
+  const queue = [rootWall.id];
+  const visited = new Set([rootWall.id]);
+
+  while (queue.length > 0) {
+    const currentId = queue.shift();
+    const currentWall = wallMap.get(currentId);
+    const currentPlacement = placed.get(currentId);
+
+    for (const conn of adjacency.get(currentId) || []) {
+      // Determine which wall is the "other" wall in this connection
+      let otherWallId, anchorWall, anchorEnd, attachedWall, attachedEnd, angleDeg;
+
+      if (conn.wallId === currentId) {
+        // Current wall is the anchor
+        otherWallId = conn.attachedWallId;
+        anchorWall = currentWall;
+        anchorEnd = conn.anchorEnd;
+        attachedWall = wallMap.get(otherWallId);
+        attachedEnd = conn.attachedEnd;
+        angleDeg = conn.angleDeg;
+      } else {
+        // Current wall is the attached; reverse the connection
+        otherWallId = conn.wallId;
+        anchorWall = currentWall;
+        anchorEnd = conn.attachedEnd;
+        attachedWall = wallMap.get(otherWallId);
+        attachedEnd = conn.anchorEnd;
+        // Reverse the angle
+        angleDeg = (360 - conn.angleDeg) % 360;
+      }
+
+      if (!attachedWall || visited.has(otherWallId)) continue;
+
+      const snap = computeSnapPosition(
+        anchorWall, anchorEnd,
+        currentPlacement.position, currentPlacement.rotation.y,
+        attachedWall, attachedEnd,
+        angleDeg
+      );
+
+      placed.set(otherWallId, snap);
+      results.push({
+        wall: attachedWall,
+        side: `snap-${otherWallId}`,
+        position: snap.position,
+        rotation: snap.rotation,
+        dimensions: {
+          length: attachedWall.length_mm,
+          height: attachedWall.height_mm,
+          thickness: WALL_THICKNESS,
+        },
+      });
+
+      visited.add(otherWallId);
+      queue.push(otherWallId);
+    }
+  }
+
+  // Place any unconnected walls at origin
+  for (const wall of walls) {
+    if (!visited.has(wall.id)) {
+      results.push({
+        wall,
+        side: `standalone-${wall.id}`,
+        position: { x: 0, y: wall.height_mm / 2, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        dimensions: { length: wall.length_mm, height: wall.height_mm, thickness: WALL_THICKNESS },
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Validate a set of connections for common errors.
+ *
+ * @param {Array} walls - All wall objects
+ * @param {Array} connections - Connection objects to validate
+ * @returns {Array<{ type: string, message: string, connectionId?: string }>}
+ */
+export function validateConnections(walls, connections) {
+  if (!connections || connections.length === 0) return [];
+
+  const errors = [];
+  const wallIds = new Set(walls.map(w => w.id));
+
+  // Track which endpoints are used
+  const usedEndpoints = new Map(); // "wallId:end" → connectionId
+
+  for (const conn of connections) {
+    // Self-connection
+    if (conn.wallId === conn.attachedWallId) {
+      errors.push({
+        type: 'self_connection',
+        message: `Connection ${conn.id} connects wall "${conn.wallId}" to itself`,
+        connectionId: conn.id,
+      });
+    }
+
+    // Missing wall IDs
+    if (!wallIds.has(conn.wallId)) {
+      errors.push({
+        type: 'missing_wall',
+        message: `Connection ${conn.id} references unknown anchor wall "${conn.wallId}"`,
+        connectionId: conn.id,
+      });
+    }
+    if (!wallIds.has(conn.attachedWallId)) {
+      errors.push({
+        type: 'missing_wall',
+        message: `Connection ${conn.id} references unknown attached wall "${conn.attachedWallId}"`,
+        connectionId: conn.id,
+      });
+    }
+
+    // Duplicate endpoint usage
+    const anchorKey = `${conn.wallId}:${conn.anchorEnd}`;
+    const attachedKey = `${conn.attachedWallId}:${conn.attachedEnd}`;
+
+    if (usedEndpoints.has(anchorKey)) {
+      errors.push({
+        type: 'duplicate_endpoint',
+        message: `Endpoint "${anchorKey}" used by both connection ${usedEndpoints.get(anchorKey)} and ${conn.id}`,
+        connectionId: conn.id,
+      });
+    } else {
+      usedEndpoints.set(anchorKey, conn.id);
+    }
+
+    if (usedEndpoints.has(attachedKey)) {
+      errors.push({
+        type: 'duplicate_endpoint',
+        message: `Endpoint "${attachedKey}" used by both connection ${usedEndpoints.get(attachedKey)} and ${conn.id}`,
+        connectionId: conn.id,
+      });
+    } else {
+      usedEndpoints.set(attachedKey, conn.id);
+    }
+
+    // Invalid angle
+    const validAngles = [0, 90, 180, 270];
+    if (!validAngles.includes(conn.angleDeg)) {
+      errors.push({
+        type: 'invalid_angle',
+        message: `Connection ${conn.id} has invalid angle ${conn.angleDeg} (must be 0, 90, 180, or 270)`,
+        connectionId: conn.id,
+      });
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Compute axis-aligned bounding box for a resolved floor plan layout.
+ *
+ * @param {Array} layoutEntries - Output of resolveFloorPlanLayout
+ * @returns {{ minX: number, maxX: number, minZ: number, maxZ: number, maxHeight: number, width: number, depth: number }}
+ */
+export function computeLayoutBounds(layoutEntries) {
+  if (!layoutEntries || layoutEntries.length === 0) {
+    return { minX: 0, maxX: 0, minZ: 0, maxZ: 0, maxHeight: 0, width: 0, depth: 0 };
+  }
+
+  let minX = Infinity, maxX = -Infinity;
+  let minZ = Infinity, maxZ = -Infinity;
+  let maxHeight = 0;
+
+  for (const entry of layoutEntries) {
+    const { position, rotation, dimensions } = entry;
+    const halfLen = dimensions.length / 2;
+    const halfThick = dimensions.thickness / 2;
+    const angle = rotation.y;
+    const cos = Math.cos(angle);
+    const sin = Math.sin(angle);
+
+    // Four corners of the wall footprint (XZ plane)
+    const corners = [
+      { dx: -halfLen, dz: -halfThick },
+      { dx: halfLen, dz: -halfThick },
+      { dx: halfLen, dz: halfThick },
+      { dx: -halfLen, dz: halfThick },
+    ];
+
+    for (const c of corners) {
+      const wx = position.x + c.dx * cos + c.dz * sin;
+      const wz = position.z - c.dx * sin + c.dz * cos;
+      minX = Math.min(minX, wx);
+      maxX = Math.max(maxX, wx);
+      minZ = Math.min(minZ, wz);
+      maxZ = Math.max(maxZ, wz);
+    }
+
+    maxHeight = Math.max(maxHeight, dimensions.height);
+  }
+
+  return {
+    minX, maxX, minZ, maxZ,
+    maxHeight,
+    width: maxX - minX,
+    depth: maxZ - minZ,
+  };
+}

--- a/devpro-wall-builder/src/utils/wallSnap.test.js
+++ b/devpro-wall-builder/src/utils/wallSnap.test.js
@@ -1,0 +1,461 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeWallEndpoint,
+  computeSnapPosition,
+  resolveFloorPlanLayout,
+  validateConnections,
+  computeLayoutBounds,
+} from './wallSnap.js';
+import { WALL_THICKNESS } from './constants.js';
+
+// ── Helpers ──
+
+function makeWall(overrides = {}) {
+  return {
+    id: 'w1',
+    name: 'Wall 1',
+    length_mm: 4800,
+    height_mm: 2700,
+    profile: 'standard',
+    deduction_left_mm: 0,
+    deduction_right_mm: 0,
+    openings: [],
+    ...overrides,
+  };
+}
+
+function approxEqual(a, b, tolerance = 0.5) {
+  return Math.abs(a - b) < tolerance;
+}
+
+// ─────────────────────────────────────────────────────────────
+// computeWallEndpoint
+// ─────────────────────────────────────────────────────────────
+describe('computeWallEndpoint', () => {
+  it('wall with no deductions: left end at -halfLen, right end at +halfLen', () => {
+    const wall = makeWall({ length_mm: 4800 });
+    const left = computeWallEndpoint(wall, 'left');
+    const right = computeWallEndpoint(wall, 'right');
+    expect(left.localX_mm).toBe(-2400);
+    expect(right.localX_mm).toBe(2400);
+  });
+
+  it('wall with left deduction: left snap point shifted inward', () => {
+    const wall = makeWall({ length_mm: 4800, deduction_left_mm: 162 });
+    const left = computeWallEndpoint(wall, 'left');
+    expect(left.localX_mm).toBe(-2400 + 162);
+  });
+
+  it('wall with right deduction: right snap point shifted inward', () => {
+    const wall = makeWall({ length_mm: 4800, deduction_right_mm: 162 });
+    const right = computeWallEndpoint(wall, 'right');
+    expect(right.localX_mm).toBe(2400 - 162);
+  });
+
+  it('wall with both deductions: both endpoints shifted inward', () => {
+    const wall = makeWall({ length_mm: 4800, deduction_left_mm: 200, deduction_right_mm: 100 });
+    const left = computeWallEndpoint(wall, 'left');
+    const right = computeWallEndpoint(wall, 'right');
+    expect(left.localX_mm).toBe(-2400 + 200);
+    expect(right.localX_mm).toBe(2400 - 100);
+  });
+
+  it('short wall with no deductions', () => {
+    const wall = makeWall({ length_mm: 1200 });
+    const left = computeWallEndpoint(wall, 'left');
+    const right = computeWallEndpoint(wall, 'right');
+    expect(left.localX_mm).toBe(-600);
+    expect(right.localX_mm).toBe(600);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// computeSnapPosition
+// ─────────────────────────────────────────────────────────────
+describe('computeSnapPosition', () => {
+  const originPos = { x: 0, y: 1350, z: 0 };
+
+  it('snap wall-B left end to wall-A right end at 90°', () => {
+    const wallA = makeWall({ id: 'A', length_mm: 4800 });
+    const wallB = makeWall({ id: 'B', length_mm: 3600, height_mm: 2700 });
+
+    const result = computeSnapPosition(
+      wallA, 'right', originPos, 0,
+      wallB, 'left', 90
+    );
+
+    // Wall A right end is at x=2400. Wall B rotated 90° so it runs along Z.
+    // Wall B left end (localX=-1800) rotated 90° maps to Z direction.
+    expect(result.rotation.y).toBeCloseTo(Math.PI / 2);
+    // Snap point is at anchor right end x=2400
+    // Wall B center should be offset so its left end hits x=2400
+    // At 90° rotation, localX maps to -Z, so center.z = snapZ - (-1800)*sin(90°) = 0 + 1800 = ...
+    // Actually let's verify the position makes geometric sense
+    expect(result.position.y).toBe(1350); // centered on its own height
+  });
+
+  it('snap at 0° (inline continuation): walls extend in same direction', () => {
+    const wallA = makeWall({ id: 'A', length_mm: 4800 });
+    const wallB = makeWall({ id: 'B', length_mm: 3600 });
+
+    const result = computeSnapPosition(
+      wallA, 'right', originPos, 0,
+      wallB, 'left', 0
+    );
+
+    // Angle should be 0 (same direction)
+    expect(result.rotation.y).toBeCloseTo(0);
+    // Wall B's left end should be at wall A's right end (x=2400)
+    // Wall B center = 2400 - (-1800)*cos(0) = 2400 + 1800 = 4200
+    expect(approxEqual(result.position.x, 4200)).toBe(true);
+    expect(approxEqual(result.position.z, 0)).toBe(true);
+  });
+
+  it('snap at 180° (U-turn): wall doubles back', () => {
+    const wallA = makeWall({ id: 'A', length_mm: 4800 });
+    const wallB = makeWall({ id: 'B', length_mm: 3600 });
+
+    const result = computeSnapPosition(
+      wallA, 'right', originPos, 0,
+      wallB, 'left', 180
+    );
+
+    expect(result.rotation.y).toBeCloseTo(Math.PI);
+    // Wall B rotated 180°, left end should align with snap point
+    // cos(180°) = -1, sin(180°) = 0
+    // center.x = 2400 - (-1800)*(-1) = 2400 - 1800 = 600
+    expect(approxEqual(result.position.x, 600)).toBe(true);
+  });
+
+  it('snap at 270° (left turn)', () => {
+    const wallA = makeWall({ id: 'A', length_mm: 4800 });
+    const wallB = makeWall({ id: 'B', length_mm: 3600 });
+
+    const result = computeSnapPosition(
+      wallA, 'right', originPos, 0,
+      wallB, 'left', 270
+    );
+
+    expect(result.rotation.y).toBeCloseTo(3 * Math.PI / 2);
+  });
+
+  it('snap with deductions on both walls', () => {
+    const wallA = makeWall({ id: 'A', length_mm: 4800, deduction_right_mm: 162 });
+    const wallB = makeWall({ id: 'B', length_mm: 3600, deduction_left_mm: 162 });
+
+    const result = computeSnapPosition(
+      wallA, 'right', originPos, 0,
+      wallB, 'left', 0
+    );
+
+    // Wall A right snap point: 2400 - 162 = 2238
+    // Wall B left snap point: -1800 + 162 = -1638
+    // Wall B center: 2238 - (-1638)*cos(0) = 2238 + 1638 = 3876
+    expect(approxEqual(result.position.x, 3876)).toBe(true);
+  });
+
+  it('snap right-to-right: both right ends meet', () => {
+    const wallA = makeWall({ id: 'A', length_mm: 4800 });
+    const wallB = makeWall({ id: 'B', length_mm: 3600 });
+
+    const result = computeSnapPosition(
+      wallA, 'right', originPos, 0,
+      wallB, 'right', 0
+    );
+
+    // Wall A right end at x=2400
+    // Wall B right endpoint localX = 1800
+    // center.x = 2400 - 1800*cos(0) = 2400 - 1800 = 600
+    expect(approxEqual(result.position.x, 600)).toBe(true);
+  });
+
+  it('different wall heights: Y positioned independently', () => {
+    const wallA = makeWall({ id: 'A', length_mm: 4800, height_mm: 2700 });
+    const wallB = makeWall({ id: 'B', length_mm: 3600, height_mm: 3050 });
+
+    const result = computeSnapPosition(
+      wallA, 'right', { x: 0, y: 1350, z: 0 }, 0,
+      wallB, 'left', 90
+    );
+
+    // Wall B should be centered on its own height
+    expect(result.position.y).toBe(3050 / 2);
+  });
+
+  it('anchor wall already rotated: attached wall position accounts for anchor rotation', () => {
+    const wallA = makeWall({ id: 'A', length_mm: 4800 });
+    const wallB = makeWall({ id: 'B', length_mm: 3600 });
+
+    // Anchor rotated 90° (running along Z)
+    const result = computeSnapPosition(
+      wallA, 'right', { x: 0, y: 1350, z: 0 }, Math.PI / 2,
+      wallB, 'left', 0
+    );
+
+    // Wall A at 90°, its right end (localX=2400) maps to:
+    // x = 0 + 2400*cos(90°) ≈ 0
+    // z = 0 - 2400*sin(90°) = -2400
+    // Wall B at 90° + 0° = 90°, its left end (localX=-1800):
+    // center.x = 0 - (-1800)*cos(90°) ≈ 0
+    // center.z = -2400 + (-1800)*sin(90°) = -2400 - 1800 = -4200
+    expect(result.rotation.y).toBeCloseTo(Math.PI / 2);
+    expect(approxEqual(result.position.x, 0, 1)).toBe(true);
+    expect(approxEqual(result.position.z, -4200)).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// resolveFloorPlanLayout
+// ─────────────────────────────────────────────────────────────
+describe('resolveFloorPlanLayout', () => {
+  it('no connections: each wall placed at origin', () => {
+    const walls = [
+      makeWall({ id: 'w1', length_mm: 4800 }),
+      makeWall({ id: 'w2', length_mm: 3600 }),
+    ];
+
+    const layout = resolveFloorPlanLayout(walls, []);
+    expect(layout).toHaveLength(2);
+    expect(layout[0].position.x).toBe(0);
+    expect(layout[1].position.x).toBe(0);
+  });
+
+  it('empty walls: returns empty array', () => {
+    expect(resolveFloorPlanLayout([], [])).toEqual([]);
+    expect(resolveFloorPlanLayout(null, [])).toEqual([]);
+  });
+
+  it('linear chain: A→B→C positions cascade', () => {
+    const walls = [
+      makeWall({ id: 'A', length_mm: 4800 }),
+      makeWall({ id: 'B', length_mm: 3600 }),
+      makeWall({ id: 'C', length_mm: 2400 }),
+    ];
+    const connections = [
+      { id: 'c1', wallId: 'A', anchorEnd: 'right', attachedWallId: 'B', attachedEnd: 'left', angleDeg: 0 },
+      { id: 'c2', wallId: 'B', anchorEnd: 'right', attachedWallId: 'C', attachedEnd: 'left', angleDeg: 0 },
+    ];
+
+    const layout = resolveFloorPlanLayout(walls, connections);
+    expect(layout).toHaveLength(3);
+
+    // All walls should be along the X axis
+    const posA = layout.find(e => e.wall.id === 'A').position;
+    const posB = layout.find(e => e.wall.id === 'B').position;
+    const posC = layout.find(e => e.wall.id === 'C').position;
+
+    // B should be to the right of A
+    expect(posB.x).toBeGreaterThan(posA.x);
+    // C should be to the right of B
+    expect(posC.x).toBeGreaterThan(posB.x);
+  });
+
+  it('L-shape: A→B at 90°', () => {
+    const walls = [
+      makeWall({ id: 'A', length_mm: 4800 }),
+      makeWall({ id: 'B', length_mm: 3600 }),
+    ];
+    const connections = [
+      { id: 'c1', wallId: 'A', anchorEnd: 'right', attachedWallId: 'B', attachedEnd: 'left', angleDeg: 90 },
+    ];
+
+    const layout = resolveFloorPlanLayout(walls, connections);
+    expect(layout).toHaveLength(2);
+
+    const entryB = layout.find(e => e.wall.id === 'B');
+    // B should be rotated 90°
+    expect(entryB.rotation.y).toBeCloseTo(Math.PI / 2);
+  });
+
+  it('rectangle: 4 walls at 90° each', () => {
+    const len = 4800;
+    const walls = [
+      makeWall({ id: 'A', length_mm: len }),
+      makeWall({ id: 'B', length_mm: len }),
+      makeWall({ id: 'C', length_mm: len }),
+      makeWall({ id: 'D', length_mm: len }),
+    ];
+    const connections = [
+      { id: 'c1', wallId: 'A', anchorEnd: 'right', attachedWallId: 'B', attachedEnd: 'left', angleDeg: 90 },
+      { id: 'c2', wallId: 'B', anchorEnd: 'right', attachedWallId: 'C', attachedEnd: 'left', angleDeg: 90 },
+      { id: 'c3', wallId: 'C', anchorEnd: 'right', attachedWallId: 'D', attachedEnd: 'left', angleDeg: 90 },
+    ];
+
+    const layout = resolveFloorPlanLayout(walls, connections);
+    expect(layout).toHaveLength(4);
+
+    // All 4 walls should be placed (not at origin)
+    const positions = layout.map(e => e.position);
+    const uniquePositions = new Set(positions.map(p => `${Math.round(p.x)},${Math.round(p.z)}`));
+    // With a square, we expect 4 distinct center positions
+    expect(uniquePositions.size).toBe(4);
+  });
+
+  it('T-junction: A has B on right and C on left', () => {
+    const walls = [
+      makeWall({ id: 'A', length_mm: 4800 }),
+      makeWall({ id: 'B', length_mm: 3600 }),
+      makeWall({ id: 'C', length_mm: 3600 }),
+    ];
+    const connections = [
+      { id: 'c1', wallId: 'A', anchorEnd: 'right', attachedWallId: 'B', attachedEnd: 'left', angleDeg: 90 },
+      { id: 'c2', wallId: 'A', anchorEnd: 'left', attachedWallId: 'C', attachedEnd: 'left', angleDeg: 270 },
+    ];
+
+    const layout = resolveFloorPlanLayout(walls, connections);
+    expect(layout).toHaveLength(3);
+
+    const entryB = layout.find(e => e.wall.id === 'B');
+    const entryC = layout.find(e => e.wall.id === 'C');
+    expect(entryB).toBeDefined();
+    expect(entryC).toBeDefined();
+  });
+
+  it('disconnected walls: connected ones placed, standalone at origin', () => {
+    const walls = [
+      makeWall({ id: 'A', length_mm: 4800 }),
+      makeWall({ id: 'B', length_mm: 3600 }),
+      makeWall({ id: 'C', length_mm: 2400 }), // not connected
+    ];
+    const connections = [
+      { id: 'c1', wallId: 'A', anchorEnd: 'right', attachedWallId: 'B', attachedEnd: 'left', angleDeg: 90 },
+    ];
+
+    const layout = resolveFloorPlanLayout(walls, connections);
+    expect(layout).toHaveLength(3);
+
+    const entryC = layout.find(e => e.wall.id === 'C');
+    expect(entryC.position.x).toBe(0);
+    expect(entryC.position.z).toBe(0);
+  });
+
+  it('root wall selection: prefers wall not attached by any connection', () => {
+    const walls = [
+      makeWall({ id: 'A', length_mm: 4800 }),
+      makeWall({ id: 'B', length_mm: 3600 }),
+    ];
+    const connections = [
+      { id: 'c1', wallId: 'A', anchorEnd: 'right', attachedWallId: 'B', attachedEnd: 'left', angleDeg: 90 },
+    ];
+
+    const layout = resolveFloorPlanLayout(walls, connections);
+    // A is the anchor (root), should be at origin
+    const entryA = layout.find(e => e.wall.id === 'A');
+    expect(entryA.position.x).toBe(0);
+    expect(entryA.position.z).toBe(0);
+  });
+
+  it('returns correct dimensions and thickness', () => {
+    const walls = [makeWall({ id: 'A', length_mm: 4800, height_mm: 2700 })];
+    const layout = resolveFloorPlanLayout(walls, []);
+    expect(layout[0].dimensions.length).toBe(4800);
+    expect(layout[0].dimensions.height).toBe(2700);
+    expect(layout[0].dimensions.thickness).toBe(WALL_THICKNESS);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// validateConnections
+// ─────────────────────────────────────────────────────────────
+describe('validateConnections', () => {
+  const walls = [
+    makeWall({ id: 'A' }),
+    makeWall({ id: 'B' }),
+    makeWall({ id: 'C' }),
+  ];
+
+  it('valid connections: no errors', () => {
+    const connections = [
+      { id: 'c1', wallId: 'A', anchorEnd: 'right', attachedWallId: 'B', attachedEnd: 'left', angleDeg: 90 },
+    ];
+    const errors = validateConnections(walls, connections);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('empty connections: no errors', () => {
+    expect(validateConnections(walls, [])).toHaveLength(0);
+    expect(validateConnections(walls, null)).toHaveLength(0);
+  });
+
+  it('wall connected to itself: error', () => {
+    const connections = [
+      { id: 'c1', wallId: 'A', anchorEnd: 'right', attachedWallId: 'A', attachedEnd: 'left', angleDeg: 90 },
+    ];
+    const errors = validateConnections(walls, connections);
+    expect(errors.some(e => e.type === 'self_connection')).toBe(true);
+  });
+
+  it('same endpoint used twice: error', () => {
+    const connections = [
+      { id: 'c1', wallId: 'A', anchorEnd: 'right', attachedWallId: 'B', attachedEnd: 'left', angleDeg: 90 },
+      { id: 'c2', wallId: 'A', anchorEnd: 'right', attachedWallId: 'C', attachedEnd: 'left', angleDeg: 0 },
+    ];
+    const errors = validateConnections(walls, connections);
+    expect(errors.some(e => e.type === 'duplicate_endpoint')).toBe(true);
+  });
+
+  it('missing wall ID: error', () => {
+    const connections = [
+      { id: 'c1', wallId: 'A', anchorEnd: 'right', attachedWallId: 'NONEXISTENT', attachedEnd: 'left', angleDeg: 90 },
+    ];
+    const errors = validateConnections(walls, connections);
+    expect(errors.some(e => e.type === 'missing_wall')).toBe(true);
+  });
+
+  it('invalid angle: error', () => {
+    const connections = [
+      { id: 'c1', wallId: 'A', anchorEnd: 'right', attachedWallId: 'B', attachedEnd: 'left', angleDeg: 45 },
+    ];
+    const errors = validateConnections(walls, connections);
+    expect(errors.some(e => e.type === 'invalid_angle')).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// computeLayoutBounds
+// ─────────────────────────────────────────────────────────────
+describe('computeLayoutBounds', () => {
+  it('empty layout: all zeros', () => {
+    const bounds = computeLayoutBounds([]);
+    expect(bounds.width).toBe(0);
+    expect(bounds.depth).toBe(0);
+    expect(bounds.maxHeight).toBe(0);
+  });
+
+  it('single wall at origin: bounds match wall dimensions', () => {
+    const layout = [{
+      wall: makeWall({ length_mm: 4800, height_mm: 2700 }),
+      position: { x: 0, y: 1350, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      dimensions: { length: 4800, height: 2700, thickness: WALL_THICKNESS },
+    }];
+
+    const bounds = computeLayoutBounds(layout);
+    expect(bounds.width).toBe(4800);
+    expect(bounds.depth).toBe(WALL_THICKNESS);
+    expect(bounds.maxHeight).toBe(2700);
+  });
+
+  it('L-shaped layout: bounds encompass both walls', () => {
+    const layout = [
+      {
+        wall: makeWall({ id: 'A', length_mm: 4800 }),
+        position: { x: 0, y: 1350, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        dimensions: { length: 4800, height: 2700, thickness: WALL_THICKNESS },
+      },
+      {
+        wall: makeWall({ id: 'B', length_mm: 3600 }),
+        position: { x: 2400, y: 1350, z: -1800 },
+        rotation: { x: 0, y: Math.PI / 2, z: 0 },
+        dimensions: { length: 3600, height: 2700, thickness: WALL_THICKNESS },
+      },
+    ];
+
+    const bounds = computeLayoutBounds(layout);
+    // Should encompass both walls
+    expect(bounds.width).toBeGreaterThan(4800);
+    expect(bounds.depth).toBeGreaterThan(WALL_THICKNESS);
+    expect(bounds.maxHeight).toBe(2700);
+  });
+});

--- a/plan.md
+++ b/plan.md
@@ -1,50 +1,178 @@
-# Fix: Dead ternary branches in EpsElevation.jsx lintel beam/EPS positioning
+# Wall Snapping Feature — Implementation Plan
 
-## Problem
-Lines 557-562 and 567-568 of `EpsElevation.jsx` have ternaries on `hasSill` that produce identical results in both branches. The intent is to position the timber beam and EPS differently depending on whether the opening has splines (windows with sills) or just plates (doors to the floor).
+## Overview
 
-From the existing exclusion logic (lines 66-78):
-- **hasSill=true** (window): opening has both **plates** (45mm) and **splines** (146mm) on each side
-- **hasSill=false** (door): opening has only **plates** (45mm) on each side
+Replace the fixed rectangular floor plan (`computeFloorPlan`) with a flexible graph-based layout where walls snap to the ends of other walls at 90-degree increments. Users select a wall in the 3D viewer, then attach other walls to either end, choosing orientation (0/90/180/270 degrees). Deductions determine the exact snap point along the wall's length.
 
-The beam/EPS should span to the outer structural edge. For windows with splines, that edge extends further out by `SPLINE_WIDTH`.
+---
 
-## Changes
+## Data Model
 
-### File: `devpro-wall-builder/src/components/EpsElevation.jsx`
+### New: `FloorPlanConnection` (persisted per-project in storage)
 
-**Step 1**: Fix `beamLeft` / `beamRight` (lines 557-562) — when `hasSill`, extend to spline outer edge:
-```jsx
-// Before (both branches identical):
-const beamLeft = hasSill
-  ? op.x - BOTTOM_PLATE + EPS_INSET
-  : op.x - BOTTOM_PLATE + EPS_INSET;
-const beamRight = hasSill
-  ? op.x + op.drawWidth + BOTTOM_PLATE - EPS_INSET
-  : op.x + op.drawWidth + BOTTOM_PLATE - EPS_INSET;
-
-// After:
-const beamLeft = hasSill
-  ? op.x - BOTTOM_PLATE - SPLINE_WIDTH + EPS_INSET
-  : op.x - BOTTOM_PLATE + EPS_INSET;
-const beamRight = hasSill
-  ? op.x + op.drawWidth + BOTTOM_PLATE + SPLINE_WIDTH - EPS_INSET
-  : op.x + op.drawWidth + BOTTOM_PLATE - EPS_INSET;
+```js
+{
+  connections: [
+    {
+      id: "conn-1",
+      wallId: "wall-A",          // the wall being snapped TO (anchor)
+      anchorEnd: "left" | "right", // which end of wallId
+      attachedWallId: "wall-B",  // the wall being attached
+      attachedEnd: "left" | "right", // which end of wall-B connects
+      angleDeg: 0 | 90 | 180 | 270  // rotation of attached wall relative to anchor wall's direction
+    }
+  ]
+}
 ```
 
-**Step 2**: Fix `epsLeft` / `epsRight` (lines 567-568) to match:
-```jsx
-// Before:
-const epsLeft = op.x - BOTTOM_PLATE + EPS_INSET;
-const epsRight = op.x + op.drawWidth + BOTTOM_PLATE - EPS_INSET;
+Deductions are already on each wall (`deduction_left_mm`, `deduction_right_mm`). The snap point for a wall's "left" end = `deduction_left_mm` inset from the geometric left edge. Similarly for "right" = `deduction_right_mm` inset from the geometric right edge.
 
-// After:
-const epsLeft = hasSill
-  ? op.x - BOTTOM_PLATE - SPLINE_WIDTH + EPS_INSET
-  : op.x - BOTTOM_PLATE + EPS_INSET;
-const epsRight = hasSill
-  ? op.x + op.drawWidth + BOTTOM_PLATE + SPLINE_WIDTH - EPS_INSET
-  : op.x + op.drawWidth + BOTTOM_PLATE - EPS_INSET;
-```
+---
 
-This ensures windows (with splines) get a wider beam/EPS span than doors (plates only), matching how the rest of the codebase treats these two cases.
+## Step-by-step Plan
+
+### Step 1: Fix existing bugs found in review
+
+**Files:** `src/utils/calculator.js`
+
+- Fix `grossLen` → `grossLength` on lines 176 and 408 (ReferenceError for gable walls with openings).
+
+This is a prerequisite — gable walls crash without it, and the snapping feature must work with all wall profiles.
+
+---
+
+### Step 2: Create `src/utils/wallSnap.js` — core snap geometry engine
+
+Pure functions, no React dependency, fully testable.
+
+**Functions:**
+
+1. **`computeWallEndpoint(wall, end)`** → `{ x_mm, z_mm }`
+   - For a wall positioned at origin facing along +X: left end is at `x = deduction_left_mm`, right end is at `x = wall.length_mm - deduction_right_mm`.
+   - Returns the snap point in local wall coordinates.
+
+2. **`computeSnapPosition(anchorWall, anchorEnd, anchorPos, anchorAngleRad, attachedWall, attachedEnd, angleDeg)`** → `{ position: {x,y,z}, rotation: {x,y,z} }`
+   - Given the anchor wall's world position/rotation and which end to snap to, compute the world position and rotation of the attached wall.
+   - The anchor's snap point = anchor wall center + offset to the specified end (accounting for deduction), transformed by the anchor's world rotation.
+   - The attached wall is then positioned so that its specified end aligns with that snap point, rotated by `angleDeg` relative to the anchor wall's facing direction.
+   - Wall thickness offset: the attached wall is offset by `WALL_THICKNESS / 2` perpendicular to the anchor wall's face so that the surfaces butt cleanly.
+
+3. **`resolveFloorPlanLayout(walls, connections)`** → `Array<{ wall, position: {x,y,z}, rotation: {x,y,z}, dimensions: {length, height, thickness} }>`
+   - Takes all walls and the connections array. Places the first wall at origin (or uses the first wall with no incoming connections as the "root").
+   - Walks the connection graph (BFS/DFS) calling `computeSnapPosition` for each connected wall.
+   - Walls with no connections are placed at origin (single-wall fallback, same as current behavior).
+   - Returns the same shape as current `computeFloorPlan` output so `ModelViewer3D` needs minimal changes.
+
+4. **`validateConnections(walls, connections)`** → `Array<{ type, message, connectionId? }>`
+   - Checks for: duplicate connections on same endpoint, circular references, missing wall IDs, walls connected to themselves.
+
+---
+
+### Step 3: Create `src/utils/wallSnap.test.js` — comprehensive unit tests
+
+**Test cases:**
+
+**`computeWallEndpoint`:**
+- Wall with no deductions → endpoints at 0 and length_mm
+- Wall with left deduction → left endpoint shifted inward
+- Wall with right deduction → right endpoint shifted inward
+- Wall with both deductions
+
+**`computeSnapPosition`:**
+- Snap wall-B's left end to wall-A's right end at 90° → verify position and rotation
+- Snap at 0° (inline/continuation) → walls extend in same direction
+- Snap at 180° (U-turn) → wall doubles back
+- Snap at 270° (left turn) → perpendicular other direction
+- Snap with deductions on both walls → verify offsets are correct
+- Snap right-to-right (both walls' right ends meet) → verify orientation flips correctly
+- Different wall heights → verify Y positioning is independent (each wall centered on its own height)
+
+**`resolveFloorPlanLayout`:**
+- No connections → each wall at origin (backward compat with single-wall)
+- Linear chain: A→B→C → verify positions cascade correctly
+- L-shape: A→B at 90° → verify classic corner
+- Rectangle: 4 walls, 4 connections at 90° each → verify it closes (gap validation)
+- T-junction: A has B on right end and C on left end → both placed correctly
+- Disconnected walls: some connected, some standalone
+
+**`validateConnections`:**
+- Valid connections → no errors
+- Wall connected to itself → error
+- Same endpoint used twice → error
+- Missing wall ID → error
+
+---
+
+### Step 4: Update `src/utils/floorPlan.js`
+
+- Keep `computeFloorPlan` as-is for backward compatibility (projects without connections).
+- Add a new export: `computeFloorPlanFromConnections(walls, connections)` that delegates to `resolveFloorPlanLayout` from `wallSnap.js` and returns the same output shape.
+- Update `computeFloorPlanCorners` and `validateCornerJoins` to work with the new arbitrary layout (or deprecate them — they assume a rectangle).
+
+---
+
+### Step 5: Update `src/utils/storage.js` — persist connections
+
+- Add `getProjectConnections(projectId)` → reads from `devpro-project-{id}-connections` key.
+- Add `saveProjectConnections(projectId, connections)` → writes to localStorage.
+- When a wall is deleted (`deleteWall`), also remove any connections referencing that wall's ID.
+- Include connections in `exportProject` / `importProject`.
+
+---
+
+### Step 6: Update `ModelViewer3D.jsx` — wall selection + snap UI
+
+**Wall selection:**
+- Add `selectedWallId` state.
+- On click of a `WallMesh`, set it as selected (highlight with emissive color or outline).
+- Show endpoint markers (small spheres/cones) at the left and right snap points of the selected wall.
+
+**Snap controls (overlay panel):**
+- When an endpoint marker is clicked, show a dropdown of available walls to attach.
+- Show orientation picker (4 buttons: 0°, 90°, 180°, 270°) with visual arrow indicators.
+- "Attach" button creates a connection and re-renders the layout.
+- "Detach" button on existing connections to remove them.
+
+**Rendering changes:**
+- Switch from `computeFloorPlan(walls)` to `computeFloorPlanFromConnections(walls, connections)` when connections exist; fall back to `computeFloorPlan(walls)` when there are none.
+- Pass `selectedWallId` and `onSelectWall` to `WallMesh`.
+- Add `SnapPointMarker` sub-component (small sphere at each endpoint).
+
+**Props change:**
+- `ModelViewer3D` now also receives `connections` and `onConnectionsChange` (or manages connections via storage internally).
+
+---
+
+### Step 7: Update `ProjectPage.jsx` — wire up connections state
+
+- Load connections from storage alongside walls.
+- Pass `connections` and `onConnectionsChange` to `ModelViewer3D`.
+- `onConnectionsChange` saves to storage and refreshes state.
+
+---
+
+### Step 8: Update scene bounds calculation
+
+Replace the fragile `walls[0]`/`walls[1]` index-based bounds with a calculation derived from the resolved floor plan positions — iterate all placed walls and compute the bounding box from their world-space extents.
+
+---
+
+## File Change Summary
+
+| File | Action |
+|------|--------|
+| `src/utils/calculator.js` | **Fix** `grossLen` bug (lines 176, 408) |
+| `src/utils/wallSnap.js` | **New** — snap geometry engine |
+| `src/utils/wallSnap.test.js` | **New** — unit tests |
+| `src/utils/floorPlan.js` | **Update** — add `computeFloorPlanFromConnections` |
+| `src/utils/storage.js` | **Update** — persist connections, clean up on wall delete |
+| `src/components/ModelViewer3D.jsx` | **Update** — selection, snap UI, use new layout |
+| `src/pages/ProjectPage.jsx` | **Update** — load/pass connections |
+
+## Out of Scope (future work)
+
+- Arbitrary angles (non-90° snapping)
+- Collision detection between walls
+- Auto-matching deductions when walls are connected
+- 3D CSG for true opening cutouts
+- Error boundary around Canvas (noted in review, separate concern)


### PR DESCRIPTION
Replace fixed rectangular floor plan with a connection-based layout engine
where walls snap to endpoints of other walls at 90-degree increments.
Deductions determine exact snap points along each wall's length.

New features:
- Wall selection in 3D viewer (click to select, highlighted with emissive)
- Snap point markers (red/green spheres) at wall endpoints
- Snap controls panel to attach/detach walls with orientation picker
- Connection persistence in localStorage and project export/import

Bug fixes:
- Fix grossLen → grossLength ReferenceError in calculator.js (gable walls)
- Wire up showWireframe toggle to actually control wireframe rendering
- Use COLORS constants instead of hardcoded color values
- Derive scene bounds from layout positions instead of fragile array indices
- Add castShadow/receiveShadow to complete the shadow pipeline

New files:
- wallSnap.js: pure geometry engine (computeWallEndpoint, computeSnapPosition,
  resolveFloorPlanLayout, validateConnections, computeLayoutBounds)
- wallSnap.test.js: 31 unit tests covering all snap functions

https://claude.ai/code/session_01YQsSdUNeJdvAcqm1F4ZRAF