### PR TITLE
Fix multi-course panel shapes and course split logic

### DIFF
--- a/devpro-wall-builder/src/components/EpsElevation.jsx
+++ b/devpro-wall-builder/src/components/EpsElevation.jsx
@@ -51,8 +51,10 @@ export default function EpsElevation({ layout, wallName }) {
   }
 
   // 2. Joint splines (146mm centred on 5mm gap between panels)
-  for (let i = 0; i < panels.length - 1; i++) {
-    const panel = panels[i];
+  // Use course 0 panels — x-positions are identical across courses
+  const basePanels = panels.filter(p => (p.course ?? 0) === 0);
+  for (let i = 0; i < basePanels.length - 1; i++) {
+    const panel = basePanels[i];
     const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
     // Skip if inside opening zone (same logic as framing elevation)
     const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
@@ -80,7 +82,7 @@ export default function EpsElevation({ layout, wallName }) {
   }
 
   // 4. Vertical plates at panel outer edges (45mm)
-  for (const p of panels) {
+  for (const p of basePanels) {
     // End panels always have a plate at their trailing edge
     if (p.type === 'end') {
       exclusions.push([p.x + p.width - BOTTOM_PLATE, p.x + p.width]);
@@ -245,7 +247,8 @@ export default function EpsElevation({ layout, wallName }) {
           <g clipPath={`url(#${clipId})`}>
 
           {/* ── Panels with EPS cores ── */}
-          {panels.map((panel, i) => {
+          {/* Use course 0 panels — internal multi-course rendering handles all courses */}
+          {panels.filter(p => (p.course ?? 0) === 0).map((panel, i) => {
             const segments = getEpsSegments(panel.x, panel.x + panel.width);
 
             const getVertExclusions = (xEdge) => {
@@ -477,13 +480,29 @@ export default function EpsElevation({ layout, wallName }) {
                     />
                   ) : null;
                 })}
-                <text
-                  x={s(panel.x + panel.width / 2)}
-                  y={s((panelMidH + yBottom) / 2) + 4}
-                  textAnchor="middle" fontSize="10" fill={LABEL_COLOR}
-                >
-                  P{panel.index + 1}
-                </text>
+                {/* Panel labels — one per course, positioned in each course's vertical region */}
+                {(isMultiCourse ? courses : [{ y: 0, height }]).map((course, ci) => {
+                  const cY = course.y;
+                  const cTop = cY + course.height;
+                  const panelCenterX = panel.x + panel.width / 2;
+                  const wallHAtCenter = heightAt ? heightAt(panelCenterX) : height;
+                  // Skip label if wall height at this panel doesn't reach this course (raked walls)
+                  if (wallHAtCenter <= cY) return null;
+                  // Clamp to cY so label stays within course when wall height < course bottom (raked walls)
+                  const courseMidTop = Math.max(Math.min(wallHAtCenter, cTop), cY);
+                  const courseMidY = (yBottom - cY + yBottom - courseMidTop) / 2;
+                  const label = isMultiCourse ? `P${i + 1}·C${ci + 1}` : `P${i + 1}`;
+                  return (
+                    <text
+                      key={`label-c${ci}`}
+                      x={s(panelCenterX)}
+                      y={s(courseMidY) + 4}
+                      textAnchor="middle" fontSize={isMultiCourse ? 8 : 10} fill={LABEL_COLOR}
+                    >
+                      {label}
+                    </text>
+                  );
+                })}
               </g>
             );
           })}
@@ -650,8 +669,8 @@ export default function EpsElevation({ layout, wallName }) {
             const splineEpsW = SPLINE_WIDTH - MAGBOARD * 2;
             const splines = [];
 
-            for (let i = 0; i < panels.length - 1; i++) {
-              const panel = panels[i];
+            for (let i = 0; i < basePanels.length - 1; i++) {
+              const panel = basePanels[i];
               const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
               const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
               const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
@@ -710,8 +729,8 @@ export default function EpsElevation({ layout, wallName }) {
           {isMultiCourse && courses.length > 1 && (() => {
             const splineEpsInset = MAGBOARD; // 10mm magboard each face
             const jointHasSpline = [];
-            for (let i = 0; i < panels.length - 1; i++) {
-              const gapCentre = panels[i].x + panels[i].width + PANEL_GAP / 2;
+            for (let i = 0; i < basePanels.length - 1; i++) {
+              const gapCentre = basePanels[i].x + basePanels[i].width + PANEL_GAP / 2;
               const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
               const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
               jointHasSpline.push(!insideLintel && !insideFooter);
@@ -722,21 +741,19 @@ export default function EpsElevation({ layout, wallName }) {
               const epsY = joinY - HALF_SPLINE + splineEpsInset;
               const epsH = SPLINE_WIDTH - 2 * splineEpsInset;
               if (epsH <= 0) return null;
-              return panels.map((panel, pi) => {
+              return basePanels.map((panel, pi) => {
                 let leftEdge;
                 if (pi > 0 && jointHasSpline[pi - 1]) {
-                  const gc = panels[pi - 1].x + panels[pi - 1].width + PANEL_GAP / 2;
+                  const gc = basePanels[pi - 1].x + basePanels[pi - 1].width + PANEL_GAP / 2;
                   leftEdge = gc + HALF_SPLINE;
                 } else {
-                  // Inset past the vertical timber plate at the panel edge
                   leftEdge = panel.x + BOTTOM_PLATE;
                 }
                 let rightEdge;
-                if (pi < panels.length - 1 && jointHasSpline[pi]) {
+                if (pi < basePanels.length - 1 && jointHasSpline[pi]) {
                   const gc = panel.x + panel.width + PANEL_GAP / 2;
                   rightEdge = gc - HALF_SPLINE;
                 } else {
-                  // Inset past the vertical timber plate at the panel edge
                   rightEdge = panel.x + panel.width - BOTTOM_PLATE;
                 }
 
@@ -861,7 +878,8 @@ export default function EpsElevation({ layout, wallName }) {
               const points = new Set([0, grossLength]);
               if (deductionLeft > 0) points.add(deductionLeft);
               if (deductionRight > 0) points.add(grossLength - deductionRight);
-              panels.forEach(p => {
+              // Use course 0 panels for measurement ticks (same x-positions across courses)
+              basePanels.forEach(p => {
                 if (p.type === 'lcut') {
                   if (p.side === 'left') {
                     const adj = p.openBottom > 0 ? WINDOW_OVERHANG : 0;

--- a/devpro-wall-builder/src/components/FramingElevation.jsx
+++ b/devpro-wall-builder/src/components/FramingElevation.jsx
@@ -204,98 +204,127 @@ export default function FramingElevation({ layout, wallName }) {
 
           {/* ── Panels ── */}
           {/* Draw panel edges as individual lines, skipping lintel/footer zones */}
-          {panels.map((panel, i) => {
-            const getExclusions = (xEdge) => {
-              const zones = [];
-              for (const l of lintels) {
-                if (l.x < xEdge && xEdge < l.x + l.width) {
-                  // Interpolate lintel height at this x position (trapezoid)
-                  const hL = l.heightLeft != null ? l.heightLeft : l.height;
-                  const hR = l.heightRight != null ? l.heightRight : l.height;
-                  const t = l.width > 0 ? (xEdge - l.x) / l.width : 0;
-                  const hAtX = hL + (hR - hL) * t;
-                  const eTop = yBottom - l.y - hAtX;
-                  const eBot = yBottom - l.y;
-                  zones.push([eTop, eBot]);
-                }
-              }
-              for (const f of footers) {
-                if (f.x < xEdge && xEdge < f.x + f.width) {
-                  zones.push([yBottom - f.height, yBottom]);
-                }
-              }
-              zones.sort((a, b) => a[0] - b[0]);
-              return zones;
-            };
-
-            const vertSegments = (xEdge) => {
-              const excl = getExclusions(xEdge);
-              const topY = yTop(xEdge);
-              const segs = [];
-              let cursor = topY;
-              for (const [eTop, eBot] of excl) {
-                if (cursor < eTop) segs.push([cursor, eTop]);
-                cursor = Math.max(cursor, eBot);
-              }
-              if (cursor < yBottom) segs.push([cursor, yBottom]);
-              return segs;
-            };
-
-            const leftX = panel.x;
-            const rightX = panel.x + panel.width;
-            const leftSegs = vertSegments(leftX);
-            const rightSegs = vertSegments(rightX);
-            const panelMidH = (yTop(leftX) + yTop(rightX)) / 2;
+          {/* Use course 0 panels for structural lines (same x-positions across courses) */}
+          {(() => {
+            const basePanels = panels.filter(p => (p.course ?? 0) === 0);
+            const posMap = new Map(basePanels.map((p, idx) => [p.x, idx]));
 
             return (
-              <g key={`panel-${i}`}>
-                {/* Top edge (sloped for raked, peaked for gable) */}
-                {panel.peakHeight ? (<>
-                  <line x1={s(leftX)} y1={s(yTop(leftX))} x2={s(panel.x + panel.peakXLocal)} y2={s(yTop(panel.x + panel.peakXLocal))} stroke={STROKE_COLOR} strokeWidth={1} strokeDasharray={DASH} />
-                  <line x1={s(panel.x + panel.peakXLocal)} y1={s(yTop(panel.x + panel.peakXLocal))} x2={s(rightX)} y2={s(yTop(rightX))} stroke={STROKE_COLOR} strokeWidth={1} strokeDasharray={DASH} />
-                </>) : (
-                  <line x1={s(leftX)} y1={s(yTop(leftX))} x2={s(rightX)} y2={s(yTop(rightX))} stroke={STROKE_COLOR} strokeWidth={1} strokeDasharray={DASH} />
-                )}
-                {/* Bottom horizontal */}
-                <line
-                  x1={s(leftX)} y1={s(yBottom)}
-                  x2={s(rightX)} y2={s(yBottom)}
-                  stroke={STROKE_COLOR} strokeWidth={1} strokeDasharray={DASH}
-                />
-                {/* Left vertical segments */}
-                {leftSegs.map(([y1, y2], j) => (
-                  <line key={`l-${j}`} x1={s(leftX)} y1={s(y1)} x2={s(leftX)} y2={s(y2)}
-                    stroke={STROKE_COLOR} strokeWidth={1} strokeDasharray={DASH} />
-                ))}
-                {/* Right vertical segments */}
-                {rightSegs.map(([y1, y2], j) => (
-                  <line key={`r-${j}`} x1={s(rightX)} y1={s(y1)} x2={s(rightX)} y2={s(y2)}
-                    stroke={STROKE_COLOR} strokeWidth={1} strokeDasharray={DASH} />
-                ))}
-                {/* Panel number */}
-                <text
-                  x={s(panel.x + panel.width / 2)}
-                  y={s((panelMidH + yBottom) / 2) + 4}
-                  textAnchor="middle" fontSize="10" fill={LABEL_COLOR}
-                >
-                  P{panel.index + 1}
-                </text>
-                {/* Panel base width */}
-                <text
-                  x={s(panel.x + panel.width / 2)}
-                  y={s(yBottom) + 14}
-                  textAnchor="middle" fontSize="9" fill="#999"
-                >
-                  {panel.width}
-                </text>
-              </g>
+              <>
+                {/* Structural edge lines — from course 0 only (edges span full wall height) */}
+                {basePanels.map((panel, i) => {
+                  const getExclusions = (xEdge) => {
+                    const zones = [];
+                    for (const l of lintels) {
+                      if (l.x < xEdge && xEdge < l.x + l.width) {
+                        const hL = l.heightLeft != null ? l.heightLeft : l.height;
+                        const hR = l.heightRight != null ? l.heightRight : l.height;
+                        const t = l.width > 0 ? (xEdge - l.x) / l.width : 0;
+                        const hAtX = hL + (hR - hL) * t;
+                        const eTop = yBottom - l.y - hAtX;
+                        const eBot = yBottom - l.y;
+                        zones.push([eTop, eBot]);
+                      }
+                    }
+                    for (const f of footers) {
+                      if (f.x < xEdge && xEdge < f.x + f.width) {
+                        zones.push([yBottom - f.height, yBottom]);
+                      }
+                    }
+                    zones.sort((a, b) => a[0] - b[0]);
+                    return zones;
+                  };
+
+                  const vertSegments = (xEdge) => {
+                    const excl = getExclusions(xEdge);
+                    const topY = yTop(xEdge);
+                    const segs = [];
+                    let cursor = topY;
+                    for (const [eTop, eBot] of excl) {
+                      if (cursor < eTop) segs.push([cursor, eTop]);
+                      cursor = Math.max(cursor, eBot);
+                    }
+                    if (cursor < yBottom) segs.push([cursor, yBottom]);
+                    return segs;
+                  };
+
+                  const leftX = panel.x;
+                  const rightX = panel.x + panel.width;
+                  const leftSegs = vertSegments(leftX);
+                  const rightSegs = vertSegments(rightX);
+
+                  return (
+                    <g key={`panel-edge-${i}`}>
+                      {/* Top edge (sloped for raked, peaked for gable) */}
+                      {panel.peakHeight ? (<>
+                        <line x1={s(leftX)} y1={s(yTop(leftX))} x2={s(panel.x + panel.peakXLocal)} y2={s(yTop(panel.x + panel.peakXLocal))} stroke={STROKE_COLOR} strokeWidth={1} strokeDasharray={DASH} />
+                        <line x1={s(panel.x + panel.peakXLocal)} y1={s(yTop(panel.x + panel.peakXLocal))} x2={s(rightX)} y2={s(yTop(rightX))} stroke={STROKE_COLOR} strokeWidth={1} strokeDasharray={DASH} />
+                      </>) : (
+                        <line x1={s(leftX)} y1={s(yTop(leftX))} x2={s(rightX)} y2={s(yTop(rightX))} stroke={STROKE_COLOR} strokeWidth={1} strokeDasharray={DASH} />
+                      )}
+                      {/* Bottom horizontal */}
+                      <line
+                        x1={s(leftX)} y1={s(yBottom)}
+                        x2={s(rightX)} y2={s(yBottom)}
+                        stroke={STROKE_COLOR} strokeWidth={1} strokeDasharray={DASH}
+                      />
+                      {/* Left vertical segments */}
+                      {leftSegs.map(([y1, y2], j) => (
+                        <line key={`l-${j}`} x1={s(leftX)} y1={s(y1)} x2={s(leftX)} y2={s(y2)}
+                          stroke={STROKE_COLOR} strokeWidth={1} strokeDasharray={DASH} />
+                      ))}
+                      {/* Right vertical segments */}
+                      {rightSegs.map(([y1, y2], j) => (
+                        <line key={`r-${j}`} x1={s(rightX)} y1={s(y1)} x2={s(rightX)} y2={s(y2)}
+                          stroke={STROKE_COLOR} strokeWidth={1} strokeDasharray={DASH} />
+                      ))}
+                      {/* Panel base width — only from course 0 */}
+                      <text
+                        x={s(panel.x + panel.width / 2)}
+                        y={s(yBottom) + 14}
+                        textAnchor="middle" fontSize="9" fill="#999"
+                      >
+                        {panel.width}
+                      </text>
+                    </g>
+                  );
+                })}
+                {/* Panel labels — per course, positioned in each course's vertical region */}
+                {panels.map((panel, i) => {
+                  const courseIdx = panel.course ?? 0;
+                  const course = courses?.[courseIdx];
+                  const cY = course?.y ?? 0;
+                  const cTop = cY + (course?.height ?? height);
+                  const panelCenterX = panel.x + panel.width / 2;
+
+                  // Vertical center of this course region
+                  // Clamp to cY so label stays within course when wall height < course bottom (raked walls)
+                  const courseMidTop = Math.max(Math.min(heightAt ? heightAt(panelCenterX) : height, cTop), cY);
+                  const courseMidY = (yBottom - cY + yBottom - courseMidTop) / 2;
+
+                  const posIdx = posMap.get(panel.x) ?? 0;
+                  const label = isMultiCourse ? `P${posIdx + 1}·C${courseIdx + 1}` : `P${posIdx + 1}`;
+
+                  return (
+                    <text
+                      key={`panel-label-${i}`}
+                      x={s(panelCenterX)}
+                      y={s(courseMidY) + 4}
+                      textAnchor="middle" fontSize={isMultiCourse ? 8 : 10} fill={LABEL_COLOR}
+                    >
+                      {label}
+                    </text>
+                  );
+                })}
+              </>
             );
-          })}
+          })()}
 
           {/* ── Vertical plates at panel outer edges (45mm) ── */}
           {(() => {
+            const basePanels = panels.filter(p => (p.course ?? 0) === 0);
             const plates = [];
-            for (const panel of panels) {
+            for (const panel of basePanels) {
               if (panel.type === 'end') {
                 plates.push(panel.x + panel.width - BOTTOM_PLATE);
               }
@@ -328,7 +357,8 @@ export default function FramingElevation({ layout, wallName }) {
 
           {/* ── Panel joint splines (146mm centred on 5mm gap) ── */}
           {/* Skip joints that fall inside a lintel or footer (opening zones) */}
-          {panels.slice(0, -1).map((panel, i) => {
+          {/* Use course 0 panels — x-positions are identical across courses */}
+          {panels.filter(p => (p.course ?? 0) === 0).slice(0, -1).map((panel, i) => {
             const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
             const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
             const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
@@ -510,16 +540,15 @@ export default function FramingElevation({ layout, wallName }) {
               if (deductionLeft > 0) points.add(deductionLeft);
               if (deductionRight > 0) points.add(grossLength - deductionRight);
 
-              panels.forEach(p => {
+              // Use course 0 panels for measurement ticks (same x-positions across courses)
+              panels.filter(p => (p.course ?? 0) === 0).forEach(p => {
                 if (p.type === 'lcut') {
                   if (p.side === 'left') {
-                    // Only subtract overhang when opening has a footer (window with sill)
                     const adj = p.openBottom > 0 ? WINDOW_OVERHANG : 0;
                     points.add(Math.round(p.x + p.width - adj));
                   } else if (p.side === 'right') {
                     points.add(Math.round(p.x + p.width));
                   } else {
-                    // Pier — right edge borders the right opening
                     const adj = p.rightOpenBottom > 0 ? WINDOW_OVERHANG : 0;
                     points.add(Math.round(p.x + p.width - adj));
                   }
@@ -605,10 +634,12 @@ export default function FramingElevation({ layout, wallName }) {
 
           {/* ── Horizontal splines at course joints (multi-course only) ── */}
           {isMultiCourse && courses.length > 1 && (() => {
+            // Use course 0 panels for x-positions (identical across courses)
+            const basePanels = panels.filter(p => (p.course ?? 0) === 0);
             // Determine which joints have vertical splines
             const jointHasSpline = [];
-            for (let i = 0; i < panels.length - 1; i++) {
-              const gapCentre = panels[i].x + panels[i].width + PANEL_GAP / 2;
+            for (let i = 0; i < basePanels.length - 1; i++) {
+              const gapCentre = basePanels[i].x + basePanels[i].width + PANEL_GAP / 2;
               const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
               const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
               jointHasSpline.push(!insideLintel && !insideFooter);
@@ -617,18 +648,18 @@ export default function FramingElevation({ layout, wallName }) {
               const joinY = yBottom - course.y;
               const spTopY = joinY - HALF_SPLINE;
               const spBotY = joinY + HALF_SPLINE;
-              return panels.map((panel, pi) => {
+              return basePanels.map((panel, pi) => {
                 // Left boundary
                 let leftEdge;
                 if (pi > 0 && jointHasSpline[pi - 1]) {
-                  const gc = panels[pi - 1].x + panels[pi - 1].width + PANEL_GAP / 2;
+                  const gc = basePanels[pi - 1].x + basePanels[pi - 1].width + PANEL_GAP / 2;
                   leftEdge = gc + HALF_SPLINE;
                 } else {
                   leftEdge = panel.x + BOTTOM_PLATE;
                 }
                 // Right boundary
                 let rightEdge;
-                if (pi < panels.length - 1 && jointHasSpline[pi]) {
+                if (pi < basePanels.length - 1 && jointHasSpline[pi]) {
                   const gc = panel.x + panel.width + PANEL_GAP / 2;
                   rightEdge = gc - HALF_SPLINE;
                 } else {

--- a/devpro-wall-builder/src/components/WallDrawing.jsx
+++ b/devpro-wall-builder/src/components/WallDrawing.jsx
@@ -97,40 +97,74 @@ export default function WallDrawing({ layout, wallName }) {
           )}
 
           {/* Panels */}
-          {panels.map((panel, i) => {
-            let fill = COLORS.PANEL;
-            let stroke = COLORS.PANEL_STROKE;
-            if (panel.type === 'lcut') { fill = COLORS.LCUT; stroke = COLORS.LCUT_STROKE; }
-            else if (panel.type === 'end') { fill = COLORS.END_CAP; stroke = COLORS.END_CAP_STROKE; }
+          {(() => {
+            // Build position index from course 0 panels (same x-positions across courses)
+            const basePanels = panels.filter(p => (p.course ?? 0) === 0);
+            const posMap = new Map(basePanels.map((p, idx) => [p.x, idx]));
 
-            const pLeft = panel.x;
-            const pRight = panel.x + panel.width;
-            const peakPt = panel.peakHeight ? `${s(panel.x + panel.peakXLocal)},${yTop(panel.x + panel.peakXLocal)} ` : '';
-            const pts = `${s(pLeft)},${yBottom} ${s(pLeft)},${yTop(pLeft)} ${peakPt}${s(pRight)},${yTop(pRight)} ${s(pRight)},${yBottom}`;
+            return panels.map((panel, i) => {
+              let fill = COLORS.PANEL;
+              let stroke = COLORS.PANEL_STROKE;
+              if (panel.type === 'lcut') { fill = COLORS.LCUT; stroke = COLORS.LCUT_STROKE; }
+              else if (panel.type === 'end') { fill = COLORS.END_CAP; stroke = COLORS.END_CAP_STROKE; }
 
-            return (
-              <g key={`panel-${i}`}>
-                <polygon points={pts} fill={fill} stroke={stroke} strokeWidth={1} opacity={0.7} />
-                {i < panels.length - 1 && (
-                  <line
-                    x1={s(pRight)} y1={yTop(pRight)}
-                    x2={s(pRight)} y2={yBottom}
-                    stroke="#aaa" strokeWidth={1} strokeDasharray="2,2"
-                  />
-                )}
-                <text
-                  x={s(pLeft + panel.width / 2)}
-                  y={yBottom - s((panel.heightLeft || height) / 2) + 4}
-                  textAnchor="middle" fontSize="11" fill={COLORS.PANEL_LABEL} fontWeight="bold"
-                >
-                  P{panel.index + 1}
-                </text>
-                <text x={s(pLeft + panel.width / 2)} y={yBottom + 14} textAnchor="middle" fontSize="9" fill="#999">
-                  {panel.width}
-                </text>
-              </g>
-            );
-          })}
+              const pLeft = panel.x;
+              const pRight = panel.x + panel.width;
+              const courseIdx = panel.course ?? 0;
+              const course = courses?.[courseIdx];
+              const cY = course?.y ?? 0;
+              const cTop = cY + (course?.height ?? height);
+
+              // Clip panel polygon to its course vertical range
+              // Clamp top edges to never go below course bottom (cY) — prevents
+              // inverted polygons when wall height < course start (raked walls)
+              const pBot = yBottom - s(cY);
+              const pTopL = yBottom - s(Math.max(Math.min(heightAt ? heightAt(pLeft) : height, cTop), cY));
+              const pTopR = yBottom - s(Math.max(Math.min(heightAt ? heightAt(pRight) : height, cTop), cY));
+              let peakPt = '';
+              if (panel.peakHeight && panel.peakXLocal != null) {
+                const peakX = panel.x + panel.peakXLocal;
+                const peakH = Math.max(Math.min(heightAt ? heightAt(peakX) : height, cTop), cY);
+                peakPt = `${s(peakX)},${yBottom - s(peakH)} `;
+              }
+              const pts = `${s(pLeft)},${pBot} ${s(pLeft)},${pTopL} ${peakPt}${s(pRight)},${pTopR} ${s(pRight)},${pBot}`;
+
+              // Label: use horizontal position index + course suffix for multi-course
+              const posIdx = posMap.get(panel.x) ?? 0;
+              const label = isMultiCourse ? `P${posIdx + 1}·C${courseIdx + 1}` : `P${posIdx + 1}`;
+
+              // Center label vertically within the course region
+              const labelY = (pBot + Math.min(pTopL, pTopR)) / 2 + 4;
+
+              // Only show width labels and divider lines for course 0 (avoid duplicates)
+              const isCourse0 = courseIdx === 0;
+
+              return (
+                <g key={`panel-${i}`}>
+                  <polygon points={pts} fill={fill} stroke={stroke} strokeWidth={1} opacity={0.7} />
+                  {isCourse0 && i < basePanels.length - 1 && (
+                    <line
+                      x1={s(pRight)} y1={yTop(pRight)}
+                      x2={s(pRight)} y2={yBottom}
+                      stroke="#aaa" strokeWidth={1} strokeDasharray="2,2"
+                    />
+                  )}
+                  <text
+                    x={s(pLeft + panel.width / 2)}
+                    y={labelY}
+                    textAnchor="middle" fontSize={isMultiCourse ? 9 : 11} fill={COLORS.PANEL_LABEL} fontWeight="bold"
+                  >
+                    {label}
+                  </text>
+                  {isCourse0 && (
+                    <text x={s(pLeft + panel.width / 2)} y={yBottom + 14} textAnchor="middle" fontSize="9" fill="#999">
+                      {panel.width}
+                    </text>
+                  )}
+                </g>
+              );
+            });
+          })()}
 
           {/* Openings */}
           {openings.map((op, i) => (
@@ -256,7 +290,8 @@ export default function WallDrawing({ layout, wallName }) {
               const points = new Set([0, grossLength]);
               if (deductionLeft > 0) points.add(deductionLeft);
               if (deductionRight > 0) points.add(grossLength - deductionRight);
-              panels.forEach(p => points.add(Math.round(p.x + p.width)));
+              // Use course 0 panels for measurement ticks (same x-positions across courses)
+              panels.filter(p => (p.course ?? 0) === 0).forEach(p => points.add(Math.round(p.x + p.width)));
               footers.forEach(f => points.add(Math.round(f.x + f.width)));
               const sorted = [...points].sort((a, b) => a - b);
               const tickY = yBottom + 22;

--- a/devpro-wall-builder/src/components/WallSummary.jsx
+++ b/devpro-wall-builder/src/components/WallSummary.jsx
@@ -38,9 +38,11 @@ export default function WallSummary({ layout, wallName }) {
   const { panels, openings, lintels, footers, height, deductionLeft, deductionRight, grossLength, isRaked, courses, isMultiCourse } = layout;
 
   // ── Count splines ──
+  // Use course 0 panels for joint detection (same x-positions across courses)
+  const basePanels = panels.filter(p => (p.course ?? 0) === 0);
   const jointSplines = [];
-  for (let i = 0; i < panels.length - 1; i++) {
-    const gapCentre = panels[i].x + panels[i].width + PANEL_GAP / 2;
+  for (let i = 0; i < basePanels.length - 1; i++) {
+    const gapCentre = basePanels[i].x + basePanels[i].width + PANEL_GAP / 2;
     const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
     const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
     if (!insideLintel && !insideFooter) jointSplines.push(gapCentre);
@@ -69,7 +71,7 @@ export default function WallSummary({ layout, wallName }) {
     exclusions.push([op.x, op.x + op.drawWidth]);
   }
 
-  for (const p of panels) {
+  for (const p of basePanels) {
     if (p.type === 'end') exclusions.push([p.x + p.width - BOTTOM_PLATE, p.x + p.width]);
     if (deductionRight === 0 && Math.abs(p.x + p.width - grossLength) < 1) exclusions.push([grossLength - BOTTOM_PLATE, grossLength]);
     if (deductionLeft === 0 && Math.abs(p.x) < 1) exclusions.push([0, BOTTOM_PLATE]);
@@ -112,7 +114,7 @@ export default function WallSummary({ layout, wallName }) {
 
   let panelEpsVol = 0;
   let panelEpsSA = 0;
-  for (const panel of panels) {
+  for (const panel of basePanels) {
     const segments = getEpsSegments(panel.x, panel.x + panel.width);
     const panelEpsH = isRaked
       ? Math.round(((panel.heightLeft + panel.heightRight) / 2) - BOTTOM_PLATE - TOP_PLATE * 2 - EPS_INSET * 2)
@@ -222,43 +224,53 @@ export default function WallSummary({ layout, wallName }) {
       </div>
 
       {/* Panel details table */}
-      {panels.length > 0 && (
-        <div style={styles.detailSection}>
-          <SectionLabel>Panel Details</SectionLabel>
-          <div style={styles.tableWrap}>
-            <table style={styles.detailTable}>
-              <thead>
-                <tr>
-                  <th style={styles.th}>#</th>
-                  <th style={styles.th}>Type</th>
-                  <th style={{ ...styles.th, textAlign: 'right' }}>Width</th>
-                  <th style={{ ...styles.th, textAlign: 'right' }}>Position</th>
-                  {isRaked && <th style={{ ...styles.th, textAlign: 'right' }}>H Left</th>}
-                  {isRaked && <th style={{ ...styles.th, textAlign: 'right' }}>H Right</th>}
-                  <th style={styles.th}>Notes</th>
-                </tr>
-              </thead>
-              <tbody>
-                {panels.map((p, i) => (
-                  <tr key={i} style={i % 2 === 0 ? styles.evenRow : undefined}>
-                    <td style={styles.td}>P{p.index + 1}</td>
-                    <td style={styles.td}>
-                      <span style={{ ...styles.badge, background: badgeColor(p.type) }}>
-                        {p.type}
-                      </span>
-                    </td>
-                    <td style={{ ...styles.td, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{p.width}</td>
-                    <td style={{ ...styles.td, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{p.x}</td>
-                    {isRaked && <td style={{ ...styles.td, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{p.heightLeft}</td>}
-                    {isRaked && <td style={{ ...styles.td, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{p.heightRight}</td>}
-                    <td style={{ ...styles.td, color: '#888' }}>{p.openingRefs ? `Opens: ${p.openingRefs.join(', ')}` : '—'}</td>
+      {panels.length > 0 && (() => {
+        const posMap = new Map(basePanels.map((p, idx) => [p.x, idx]));
+        return (
+          <div style={styles.detailSection}>
+            <SectionLabel>Panel Details</SectionLabel>
+            <div style={styles.tableWrap}>
+              <table style={styles.detailTable}>
+                <thead>
+                  <tr>
+                    <th style={styles.th}>#</th>
+                    {isMultiCourse && <th style={styles.th}>Course</th>}
+                    <th style={styles.th}>Type</th>
+                    <th style={{ ...styles.th, textAlign: 'right' }}>Width</th>
+                    <th style={{ ...styles.th, textAlign: 'right' }}>Position</th>
+                    <th style={{ ...styles.th, textAlign: 'right' }}>H Left</th>
+                    <th style={{ ...styles.th, textAlign: 'right' }}>H Right</th>
+                    <th style={styles.th}>Notes</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {panels.map((p, i) => {
+                    const posIdx = posMap.get(p.x) ?? 0;
+                    const courseIdx = p.course ?? 0;
+                    const label = isMultiCourse ? `P${posIdx + 1}·C${courseIdx + 1}` : `P${posIdx + 1}`;
+                    return (
+                      <tr key={i} style={i % 2 === 0 ? styles.evenRow : undefined}>
+                        <td style={styles.td}>{label}</td>
+                        {isMultiCourse && <td style={styles.td}>C{courseIdx + 1}</td>}
+                        <td style={styles.td}>
+                          <span style={{ ...styles.badge, background: badgeColor(p.type) }}>
+                            {p.type}
+                          </span>
+                        </td>
+                        <td style={{ ...styles.td, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{p.width}</td>
+                        <td style={{ ...styles.td, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{p.x}</td>
+                        <td style={{ ...styles.td, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{p.heightLeft}</td>
+                        <td style={{ ...styles.td, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{p.heightRight}</td>
+                        <td style={{ ...styles.td, color: '#888' }}>{p.openingRefs ? `Opens: ${p.openingRefs.join(', ')}` : '—'}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
           </div>
-        </div>
-      )}
+        );
+      })()}
     </div>
   );
 }

--- a/devpro-wall-builder/src/utils/calculator.js
+++ b/devpro-wall-builder/src/utils/calculator.js
@@ -53,7 +53,7 @@ function buildHeightFn(wall) {
  *        (future project-level optimizer can pass a custom subset)
  * @returns {{ courses: Array<{y: number, height: number, sheetHeight: number}>, isMultiCourse: boolean }}
  */
-export function computeCourses(wallHeight, availableSheets = STOCK_SHEET_HEIGHTS) {
+export function computeCourses(wallHeight, availableSheets = STOCK_SHEET_HEIGHTS, preferredBottom = null) {
   const maxSheet = Math.max(...availableSheets);
 
   if (wallHeight <= maxSheet) {
@@ -65,7 +65,36 @@ export function computeCourses(wallHeight, availableSheets = STOCK_SHEET_HEIGHTS
     };
   }
 
-  // Try all two-course combinations; pick the one with minimum waste
+  // If a preferred bottom course height is specified, use it directly
+  if (preferredBottom && preferredBottom < wallHeight) {
+    const bottomSheet = availableSheets.find(s => s >= preferredBottom) || maxSheet;
+    const topHeight = wallHeight - preferredBottom;
+    const topSheet = availableSheets.find(s => s >= topHeight) || maxSheet;
+    if (topHeight <= maxSheet) {
+      return {
+        courses: [
+          { y: 0, height: preferredBottom, sheetHeight: bottomSheet },
+          { y: preferredBottom, height: topHeight, sheetHeight: topSheet },
+        ],
+        isMultiCourse: true,
+      };
+    }
+    // Top still exceeds max sheet — stack preferred bottom + remaining courses
+    const courses = [{ y: 0, height: preferredBottom, sheetHeight: bottomSheet }];
+    let remaining = topHeight;
+    let y = preferredBottom;
+    while (remaining > maxSheet) {
+      courses.push({ y, height: maxSheet, sheetHeight: maxSheet });
+      y += maxSheet;
+      remaining -= maxSheet;
+    }
+    const sheet = availableSheets.find(s => s >= remaining) || maxSheet;
+    courses.push({ y, height: remaining, sheetHeight: sheet });
+    return { courses, isMultiCourse: true };
+  }
+
+  // No preference — try all two-course combinations; pick the one with minimum waste
+  // Default: prefer smaller bottom sheet (less material usage)
   let best = null;
   let bestWaste = Infinity;
 
@@ -75,8 +104,8 @@ export function computeCourses(wallHeight, availableSheets = STOCK_SHEET_HEIGHTS
     const topSheet = availableSheets.find(s => s >= topHeight);
     if (!topSheet) continue; // top too tall for any single sheet
     const waste = topSheet - topHeight;
-    // Prefer less waste; on tie prefer taller bottom (structurally stronger)
-    if (waste < bestWaste || (waste === bestWaste && bottomSheet > (best?.bottomSheet || 0))) {
+    // Prefer less waste; on tie prefer smaller bottom (less material)
+    if (waste < bestWaste || (waste === bestWaste && bottomSheet < (best?.bottomSheet || Infinity))) {
       bestWaste = waste;
       best = { bottomSheet, topHeight, topSheet };
     }
@@ -417,17 +446,136 @@ export function calculateWallLayout(wall) {
 
   // Compute vertical course layout (multi-course for walls > 3050mm)
   // Use maxHeight so raked/gable walls trigger multi-course when any part exceeds sheet height
-  const { courses, isMultiCourse } = computeCourses(maxHeight);
-
-  // Per-panel sheet height assignment
-  // Each panel gets its own sheetHeight based on its individual max height.
-  // On raked/gable walls, panels have varying heights and may need different sheets.
+  // Determine preferred bottom course height based on wall profile
   const maxStockSheet = Math.max(...STOCK_SHEET_HEIGHTS);
-  panels.forEach(panel => {
-    const panelMaxH = Math.max(panel.heightLeft, panel.heightRight, panel.peakHeight || 0);
-    panel.sheetHeight = STOCK_SHEET_HEIGHTS.find(s => s >= panelMaxH) || maxStockSheet;
-    panel.isMultiCourse = panelMaxH > maxStockSheet;
-  });
+  let preferredBottom = wall.preferred_sheet_height || null;
+  if (!preferredBottom && maxHeight > maxStockSheet) {
+    if (profile === WALL_PROFILES.RAKED) {
+      // Use the actual lower wall height as the course split point
+      // (the sheet that covers it is tracked separately in sheetHeight)
+      const lowerH = Math.min(height, heightAt ? heightAt(grossLength) : height);
+      preferredBottom = lowerH;
+    } else if (profile === WALL_PROFILES.GABLE) {
+      // Use the actual base wall height as the course split point
+      preferredBottom = height;
+    } else {
+      // Standard flat wall — default to smaller sheet
+      preferredBottom = Math.min(...STOCK_SHEET_HEIGHTS);
+    }
+  }
+
+  const { courses, isMultiCourse } = computeCourses(maxHeight, STOCK_SHEET_HEIGHTS, preferredBottom);
+
+  // ── Replicate panels across courses ──
+  // The panels array so far represents horizontal positions for a single row.
+  // For multi-course walls, each course gets its own copy with adjusted heights.
+  let allPanels;
+
+  if (!isMultiCourse) {
+    // Single course — tag panels and assign sheet heights as before
+    panels.forEach(panel => {
+      panel.course = 0;
+      panel.courseY = 0;
+      const panelMaxH = Math.max(panel.heightLeft, panel.heightRight, panel.peakHeight || 0);
+      panel.sheetHeight = STOCK_SHEET_HEIGHTS.find(s => s >= panelMaxH) || maxStockSheet;
+      panel.isMultiCourse = false;
+    });
+    allPanels = panels;
+  } else {
+    allPanels = [];
+
+    for (let ci = 0; ci < courses.length; ci++) {
+      const course = courses[ci];
+      const courseTop = course.y + course.height;
+
+      for (const basePanel of panels) {
+        // Compute this panel's absolute height range at its edges for this course
+        const absLeftH = Math.max(basePanel.heightLeft, basePanel.heightRight, basePanel.peakHeight || 0) > 0
+          ? basePanel.heightLeft : height;
+        const absRightH = Math.max(basePanel.heightLeft, basePanel.heightRight, basePanel.peakHeight || 0) > 0
+          ? basePanel.heightRight : height;
+
+        // For raked/gable, use heightAt to get absolute heights at panel edges
+        const absHL = Math.round(heightAt(basePanel.x));
+        const absHR = Math.round(heightAt(basePanel.x + basePanel.width));
+
+        // Panel height within this course
+        const courseHL = Math.max(0, Math.min(absHL, courseTop) - course.y);
+        const courseHR = Math.max(0, Math.min(absHR, courseTop) - course.y);
+
+        // Skip if this panel has zero height in this course
+        if (courseHL <= 0 && courseHR <= 0) continue;
+
+        // Determine panel type for this course
+        let panelType = basePanel.type;
+        let panelProps = {};
+
+        if (basePanel.type === 'lcut') {
+          // Check if the opening intersects this course's vertical range
+          const openBottom = basePanel.openBottom || 0;
+          const openTop = basePanel.openTop || 0;
+          const overlaps = openBottom < courseTop && openTop > course.y;
+
+          if (overlaps) {
+            // Opening intersects this course — keep as L-cut with adjusted open coords
+            panelProps = {
+              openingRefs: basePanel.openingRefs,
+              side: basePanel.side,
+              openLeft: basePanel.openLeft,
+              openRight: basePanel.openRight,
+              openBottom: Math.max(0, openBottom - course.y),
+              openTop: Math.min(course.height, openTop - course.y),
+              openingType: basePanel.openingType,
+            };
+            if (basePanel.side === 'pier') {
+              panelProps.rightOpenLeft = basePanel.rightOpenLeft;
+              panelProps.rightOpenRight = basePanel.rightOpenRight;
+              panelProps.rightOpenBottom = Math.max(0, (basePanel.rightOpenBottom || 0) - course.y);
+              panelProps.rightOpenTop = Math.min(course.height, (basePanel.rightOpenTop || 0) - course.y);
+              panelProps.rightOpeningType = basePanel.rightOpeningType;
+            }
+          } else {
+            // Opening doesn't reach this course — emit as full or end panel
+            panelType = basePanel.width < PANEL_WIDTH ? 'end' : 'full';
+          }
+        }
+
+        // Gable peak detection for this course
+        let panelPeakHeight;
+        let panelPeakXLocal;
+        if (profile === WALL_PROFILES.GABLE && basePanel.peakHeight != null) {
+          const absPeakH = basePanel.peakHeight;
+          const coursePeakH = Math.max(0, Math.min(absPeakH, courseTop) - course.y);
+          if (coursePeakH > 0) {
+            panelPeakHeight = coursePeakH;
+            panelPeakXLocal = basePanel.peakXLocal;
+          }
+        }
+
+        const panelMaxH = Math.max(courseHL, courseHR, panelPeakHeight || 0);
+
+        allPanels.push({
+          x: basePanel.x,
+          width: basePanel.width,
+          pitch: basePanel.pitch,
+          height: course.height,
+          type: panelType,
+          heightLeft: courseHL,
+          heightRight: courseHR,
+          peakHeight: panelPeakHeight,
+          peakXLocal: panelPeakXLocal,
+          course: ci,
+          courseY: course.y,
+          sheetHeight: course.sheetHeight,
+          isMultiCourse: true,
+          ...panelProps,
+        });
+      }
+    }
+
+    // Re-index all panels
+    allPanels.forEach((p, i) => { p.index = i; });
+  }
 
   return {
     grossLength,
@@ -447,16 +595,16 @@ export function calculateWallLayout(wall) {
       : undefined,
     deductionLeft: dedLeft,
     deductionRight: dedRight,
-    panels,
+    panels: allPanels,
     openings: openingDetails,
     footers,
     lintels,
     courses,
     isMultiCourse,
-    totalPanels: panels.length,
-    fullPanels: panels.filter(p => p.type === 'full').length,
-    lcutPanels: panels.filter(p => p.type === 'lcut').length,
-    endPanels: panels.filter(p => p.type === 'end').length,
+    totalPanels: allPanels.length,
+    fullPanels: allPanels.filter(p => p.type === 'full').length,
+    lcutPanels: allPanels.filter(p => p.type === 'lcut').length,
+    endPanels: allPanels.filter(p => p.type === 'end').length,
   };
 }
 

--- a/devpro-wall-builder/src/utils/calculator.test.js
+++ b/devpro-wall-builder/src/utils/calculator.test.js
@@ -1,0 +1,624 @@
+import { describe, it, expect } from 'vitest';
+import { calculateWallLayout, computeCourses } from './calculator.js';
+import {
+  PANEL_WIDTH,
+  PANEL_PITCH,
+  STOCK_SHEET_HEIGHTS,
+  WALL_PROFILES,
+  OPENING_TYPES,
+} from './constants.js';
+
+// ── Helpers ──
+
+function makeWall(overrides = {}) {
+  return {
+    length_mm: 9740,
+    height_mm: 2440,
+    profile: WALL_PROFILES.STANDARD,
+    deduction_left_mm: 0,
+    deduction_right_mm: 0,
+    openings: [],
+    ...overrides,
+  };
+}
+
+// ── computeCourses ──
+
+describe('computeCourses', () => {
+  it('returns single course for wall within max sheet height', () => {
+    const { courses, isMultiCourse } = computeCourses(2440);
+    expect(isMultiCourse).toBe(false);
+    expect(courses).toHaveLength(1);
+    expect(courses[0].y).toBe(0);
+    expect(courses[0].height).toBe(2440);
+  });
+
+  it('returns two courses for wall exceeding max sheet height', () => {
+    const { courses, isMultiCourse } = computeCourses(4000);
+    expect(isMultiCourse).toBe(true);
+    expect(courses).toHaveLength(2);
+    expect(courses[0].y).toBe(0);
+    expect(courses[1].y).toBe(courses[0].height);
+    // Total height covered should equal wall height
+    const totalH = courses.reduce((sum, c) => sum + c.height, 0);
+    expect(totalH).toBe(4000);
+  });
+
+  it('returns three courses for very tall wall', () => {
+    // 3050 + 3050 = 6100, so a 7000mm wall needs 3 courses
+    const { courses, isMultiCourse } = computeCourses(7000);
+    expect(isMultiCourse).toBe(true);
+    expect(courses.length).toBeGreaterThanOrEqual(3);
+    const totalH = courses.reduce((sum, c) => sum + c.height, 0);
+    expect(totalH).toBe(7000);
+  });
+});
+
+// ── Single course (baseline — existing behaviour should not change) ──
+
+describe('calculateWallLayout — single course', () => {
+  it('counts panels correctly for a simple wall', () => {
+    const wall = makeWall({ length_mm: 9740, height_mm: 2440 });
+    const layout = calculateWallLayout(wall);
+
+    expect(layout.isMultiCourse).toBe(false);
+    expect(layout.totalPanels).toBe(layout.panels.length);
+    expect(layout.totalPanels).toBeGreaterThan(0);
+    // All panels should have no course property or course === 0
+    layout.panels.forEach(p => {
+      expect(p.course ?? 0).toBe(0);
+    });
+  });
+
+  it('counts L-cut panels around a window', () => {
+    const wall = makeWall({
+      length_mm: 9740,
+      height_mm: 2440,
+      openings: [{
+        ref: 'W1',
+        type: OPENING_TYPES.WINDOW,
+        width_mm: 1200,
+        height_mm: 1200,
+        sill_mm: 900,
+        position_from_left_mm: 4000,
+      }],
+    });
+    const layout = calculateWallLayout(wall);
+    expect(layout.isMultiCourse).toBe(false);
+    expect(layout.lcutPanels).toBeGreaterThan(0);
+    expect(layout.totalPanels).toBe(
+      layout.fullPanels + layout.lcutPanels + layout.endPanels
+    );
+  });
+});
+
+// ── Multi-course panel counting (THE FIX) ──
+
+describe('calculateWallLayout — multi-course panel counts', () => {
+  it('doubles panel count for a 2-course standard wall with no openings', () => {
+    // 4000mm wall → 2 courses (e.g., 2745 + 1255)
+    const wall = makeWall({ length_mm: 9740, height_mm: 4000 });
+    const layout = calculateWallLayout(wall);
+
+    expect(layout.isMultiCourse).toBe(true);
+    expect(layout.courses).toHaveLength(2);
+
+    // Single-course version of same wall width for comparison
+    const singleCourse = calculateWallLayout(
+      makeWall({ length_mm: 9740, height_mm: 2440 })
+    );
+
+    // Multi-course should have 2× the panels
+    expect(layout.totalPanels).toBe(singleCourse.totalPanels * 2);
+  });
+
+  it('triples panel count for a 3-course wall with no openings', () => {
+    // 7000mm → 3 courses
+    const wall = makeWall({ length_mm: 9740, height_mm: 7000 });
+    const layout = calculateWallLayout(wall);
+
+    expect(layout.isMultiCourse).toBe(true);
+    expect(layout.courses.length).toBeGreaterThanOrEqual(3);
+
+    const singleCourse = calculateWallLayout(
+      makeWall({ length_mm: 9740, height_mm: 2440 })
+    );
+
+    expect(layout.totalPanels).toBe(
+      singleCourse.totalPanels * layout.courses.length
+    );
+  });
+
+  it('each panel has a course index', () => {
+    const wall = makeWall({ length_mm: 9740, height_mm: 4000 });
+    const layout = calculateWallLayout(wall);
+
+    // Every panel should have a course property
+    layout.panels.forEach(p => {
+      expect(p.course).toBeDefined();
+      expect(p.course).toBeGreaterThanOrEqual(0);
+      expect(p.course).toBeLessThan(layout.courses.length);
+    });
+
+    // Should have panels in both course 0 and course 1
+    const course0 = layout.panels.filter(p => p.course === 0);
+    const course1 = layout.panels.filter(p => p.course === 1);
+    expect(course0.length).toBeGreaterThan(0);
+    expect(course1.length).toBeGreaterThan(0);
+  });
+
+  it('panel y offsets match course positions', () => {
+    const wall = makeWall({ length_mm: 9740, height_mm: 4000 });
+    const layout = calculateWallLayout(wall);
+
+    for (const panel of layout.panels) {
+      const course = layout.courses[panel.course];
+      expect(panel.courseY).toBe(course.y);
+    }
+  });
+
+  it('panel heights match their course heights', () => {
+    const wall = makeWall({ length_mm: 4815, height_mm: 4000 });
+    const layout = calculateWallLayout(wall);
+
+    const course0Panels = layout.panels.filter(p => p.course === 0);
+    const course1Panels = layout.panels.filter(p => p.course === 1);
+    const bottomCourse = layout.courses[0];
+    const topCourse = layout.courses[1];
+
+    // Bottom course panels should use the bottom course height
+    for (const p of course0Panels) {
+      expect(p.heightLeft).toBe(bottomCourse.height);
+      expect(p.heightRight).toBe(bottomCourse.height);
+    }
+
+    // Top course panels should use the top course height
+    for (const p of course1Panels) {
+      expect(p.heightLeft).toBe(topCourse.height);
+      expect(p.heightRight).toBe(topCourse.height);
+    }
+  });
+
+  it('x positions are the same across courses (no openings)', () => {
+    const wall = makeWall({ length_mm: 9740, height_mm: 4000 });
+    const layout = calculateWallLayout(wall);
+
+    const course0Xs = layout.panels
+      .filter(p => p.course === 0)
+      .map(p => p.x)
+      .sort((a, b) => a - b);
+    const course1Xs = layout.panels
+      .filter(p => p.course === 1)
+      .map(p => p.x)
+      .sort((a, b) => a - b);
+
+    expect(course0Xs).toEqual(course1Xs);
+  });
+
+  it('sheetHeight per panel matches its course sheetHeight', () => {
+    const wall = makeWall({ length_mm: 4815, height_mm: 4000 });
+    const layout = calculateWallLayout(wall);
+
+    for (const panel of layout.panels) {
+      const course = layout.courses[panel.course];
+      expect(panel.sheetHeight).toBe(course.sheetHeight);
+    }
+  });
+
+  it('summary counts reflect all courses', () => {
+    const wall = makeWall({ length_mm: 9740, height_mm: 4000 });
+    const layout = calculateWallLayout(wall);
+
+    expect(layout.totalPanels).toBe(layout.panels.length);
+    expect(layout.totalPanels).toBe(
+      layout.fullPanels + layout.lcutPanels + layout.endPanels
+    );
+  });
+});
+
+// ── Multi-course with openings ──
+
+describe('calculateWallLayout — multi-course with openings', () => {
+  it('opening only in bottom course: top course gets full panels', () => {
+    // Window: sill 500, height 1200 → top at 1700mm
+    // Course split at ~2745mm → opening is entirely in bottom course
+    const wall = makeWall({
+      length_mm: 9740,
+      height_mm: 4000,
+      openings: [{
+        ref: 'W1',
+        type: OPENING_TYPES.WINDOW,
+        width_mm: 1200,
+        height_mm: 1200,
+        sill_mm: 500,
+        position_from_left_mm: 4000,
+      }],
+    });
+    const layout = calculateWallLayout(wall);
+
+    expect(layout.isMultiCourse).toBe(true);
+
+    // Bottom course should have L-cut panels
+    const course0Lcuts = layout.panels.filter(
+      p => p.course === 0 && p.type === 'lcut'
+    );
+    expect(course0Lcuts.length).toBeGreaterThan(0);
+
+    // Top course should have NO L-cut panels at the opening position
+    // (opening doesn't reach the top course)
+    const course1Lcuts = layout.panels.filter(
+      p => p.course === 1 && p.type === 'lcut'
+    );
+    expect(course1Lcuts.length).toBe(0);
+  });
+
+  it('door spanning both courses: both courses get L-cuts', () => {
+    // Door: sill 0, height 3200mm → spans both courses (split at ~2745)
+    const wall = makeWall({
+      length_mm: 9740,
+      height_mm: 4000,
+      openings: [{
+        ref: 'D1',
+        type: OPENING_TYPES.DOOR,
+        width_mm: 900,
+        height_mm: 3200,
+        sill_mm: 0,
+        position_from_left_mm: 4000,
+      }],
+    });
+    const layout = calculateWallLayout(wall);
+
+    expect(layout.isMultiCourse).toBe(true);
+
+    // Both courses should have L-cut panels around the door
+    const course0Lcuts = layout.panels.filter(
+      p => p.course === 0 && p.type === 'lcut'
+    );
+    const course1Lcuts = layout.panels.filter(
+      p => p.course === 1 && p.type === 'lcut'
+    );
+    expect(course0Lcuts.length).toBeGreaterThan(0);
+    expect(course1Lcuts.length).toBeGreaterThan(0);
+  });
+
+  it('total panel count with opening-in-bottom-only exceeds single-course count', () => {
+    const wall = makeWall({
+      length_mm: 9740,
+      height_mm: 4000,
+      openings: [{
+        ref: 'W1',
+        type: OPENING_TYPES.WINDOW,
+        width_mm: 1200,
+        height_mm: 1200,
+        sill_mm: 500,
+        position_from_left_mm: 4000,
+      }],
+    });
+    const layout = calculateWallLayout(wall);
+
+    // Should be more panels than the single-course bottom row alone
+    const course0Count = layout.panels.filter(p => p.course === 0).length;
+    expect(layout.totalPanels).toBeGreaterThan(course0Count);
+  });
+});
+
+// ── Multi-course raked wall ──
+
+describe('calculateWallLayout — multi-course raked', () => {
+  it('counts panels per course for a raked multi-course wall', () => {
+    // Left height 4000, right height 3200 — both exceed max sheet
+    const wall = makeWall({
+      length_mm: 9740,
+      height_mm: 4000,
+      height_right_mm: 3200,
+      profile: WALL_PROFILES.RAKED,
+    });
+    const layout = calculateWallLayout(wall);
+
+    expect(layout.isMultiCourse).toBe(true);
+    expect(layout.courses.length).toBeGreaterThanOrEqual(2);
+
+    // Should have panels in multiple courses
+    const courseIndices = [...new Set(layout.panels.map(p => p.course))];
+    expect(courseIndices.length).toBe(layout.courses.length);
+  });
+});
+
+// ── Course split height logic ──
+
+describe('computeCourses — preferredBottom parameter', () => {
+  it('uses preferredBottom as bottom course height when provided', () => {
+    const { courses } = computeCourses(4000, STOCK_SHEET_HEIGHTS, 2745);
+    expect(courses[0].height).toBe(2745);
+    expect(courses[0].sheetHeight).toBe(2745);
+    expect(courses[1].height).toBe(4000 - 2745);
+  });
+
+  it('uses 3050 as bottom course when preferred', () => {
+    const { courses } = computeCourses(4000, STOCK_SHEET_HEIGHTS, 3050);
+    expect(courses[0].height).toBe(3050);
+    expect(courses[0].sheetHeight).toBe(3050);
+    expect(courses[1].height).toBe(4000 - 3050);
+  });
+
+  it('sets sheetHeight to covering stock sheet when preferredBottom is not a stock size', () => {
+    // preferredBottom=2700 → sheetHeight should be 2745 (smallest stock sheet ≥ 2700)
+    const { courses } = computeCourses(4800, STOCK_SHEET_HEIGHTS, 2700);
+    expect(courses[0].height).toBe(2700);
+    expect(courses[0].sheetHeight).toBe(2745);
+    expect(courses[1].height).toBe(4800 - 2700);
+  });
+
+  it('ignores preferredBottom for single-course walls', () => {
+    const { courses, isMultiCourse } = computeCourses(2440, STOCK_SHEET_HEIGHTS, 2745);
+    expect(isMultiCourse).toBe(false);
+    expect(courses).toHaveLength(1);
+  });
+
+  it('falls back to waste-minimization when preferredBottom is not provided', () => {
+    const { courses } = computeCourses(4000);
+    expect(courses).toHaveLength(2);
+    // Should still produce a valid split
+    expect(courses[0].height + courses[1].height).toBe(4000);
+  });
+});
+
+describe('calculateWallLayout — course split matches wall geometry', () => {
+  it('flat wall: defaults to smaller stock sheet (2745) for bottom course', () => {
+    const wall = makeWall({ length_mm: 9740, height_mm: 4000 });
+    const layout = calculateWallLayout(wall);
+    expect(layout.isMultiCourse).toBe(true);
+    expect(layout.courses[0].height).toBe(2745);
+    expect(layout.courses[0].sheetHeight).toBe(2745);
+  });
+
+  it('flat wall: preferred_sheet_height=3050 uses 3050 for bottom course', () => {
+    const wall = makeWall({
+      length_mm: 9740,
+      height_mm: 4000,
+      preferred_sheet_height: 3050,
+    });
+    const layout = calculateWallLayout(wall);
+    expect(layout.isMultiCourse).toBe(true);
+    expect(layout.courses[0].height).toBe(3050);
+  });
+
+  it('flat wall: preferred_sheet_height=2745 uses 2745 for bottom course', () => {
+    const wall = makeWall({
+      length_mm: 9740,
+      height_mm: 4000,
+      preferred_sheet_height: 2745,
+    });
+    const layout = calculateWallLayout(wall);
+    expect(layout.isMultiCourse).toBe(true);
+    expect(layout.courses[0].height).toBe(2745);
+  });
+
+  it('raked wall: bottom course height = actual lower wall height', () => {
+    // Left 4000mm, right 2600mm → lower = 2600 → course height = 2600, sheet = 2745
+    const wall = makeWall({
+      length_mm: 9740,
+      height_mm: 4000,
+      height_right_mm: 2600,
+      profile: WALL_PROFILES.RAKED,
+    });
+    const layout = calculateWallLayout(wall);
+    expect(layout.isMultiCourse).toBe(true);
+    expect(layout.courses[0].height).toBe(2600);
+    expect(layout.courses[0].sheetHeight).toBe(2745);
+  });
+
+  it('raked wall: lower height 2800 → bottom course height = 2800, sheet = 3050', () => {
+    // Left 4000mm, right 2800mm → lower = 2800 → course height = 2800, sheet = 3050
+    const wall = makeWall({
+      length_mm: 9740,
+      height_mm: 4000,
+      height_right_mm: 2800,
+      profile: WALL_PROFILES.RAKED,
+    });
+    const layout = calculateWallLayout(wall);
+    expect(layout.isMultiCourse).toBe(true);
+    expect(layout.courses[0].height).toBe(2800);
+    expect(layout.courses[0].sheetHeight).toBe(3050);
+  });
+
+  it('raked wall: lower height exceeds all sheets → uses max sheet', () => {
+    // Left 7000mm, right 3200mm → lower = 3200 > 3050 → course height = 3200, sheet = 3050 (max)
+    const wall = makeWall({
+      length_mm: 9740,
+      height_mm: 7000,
+      height_right_mm: 3200,
+      profile: WALL_PROFILES.RAKED,
+    });
+    const layout = calculateWallLayout(wall);
+    expect(layout.isMultiCourse).toBe(true);
+    expect(layout.courses[0].height).toBe(3200);
+    expect(layout.courses[0].sheetHeight).toBe(3050);
+  });
+
+  it('raked wall: preferred_sheet_height overrides auto-detection', () => {
+    const wall = makeWall({
+      length_mm: 9740,
+      height_mm: 4000,
+      height_right_mm: 2600,
+      profile: WALL_PROFILES.RAKED,
+      preferred_sheet_height: 3050,
+    });
+    const layout = calculateWallLayout(wall);
+    expect(layout.isMultiCourse).toBe(true);
+    expect(layout.courses[0].height).toBe(3050);
+  });
+
+  it('gable wall: bottom course height = actual base wall height', () => {
+    // Base 2600mm, peak 4500mm → course height = 2600, sheet = 2745
+    const wall = makeWall({
+      length_mm: 9740,
+      height_mm: 2600,
+      peak_height_mm: 4500,
+      profile: WALL_PROFILES.GABLE,
+    });
+    const layout = calculateWallLayout(wall);
+    // Only multi-course if maxHeight > 3050
+    if (layout.isMultiCourse) {
+      expect(layout.courses[0].height).toBe(2600);
+      expect(layout.courses[0].sheetHeight).toBe(2745);
+    }
+  });
+
+  it('gable wall: base 2800, peak 4000 → bottom course = 2800, sheet = 3050', () => {
+    const wall = makeWall({
+      length_mm: 9740,
+      height_mm: 2800,
+      peak_height_mm: 4000,
+      profile: WALL_PROFILES.GABLE,
+    });
+    const layout = calculateWallLayout(wall);
+    if (layout.isMultiCourse) {
+      expect(layout.courses[0].height).toBe(2800);
+      expect(layout.courses[0].sheetHeight).toBe(3050);
+    }
+  });
+
+  it('single-course wall is unaffected by preferred_sheet_height', () => {
+    const wall = makeWall({
+      length_mm: 9740,
+      height_mm: 2440,
+      preferred_sheet_height: 3050,
+    });
+    const layout = calculateWallLayout(wall);
+    expect(layout.isMultiCourse).toBe(false);
+  });
+});
+
+// ── Raked wall panel shapes — lower height below course split ──
+
+describe('calculateWallLayout — raked/gable wall panel clipping', () => {
+  it('raked: no C2 panels where wall height is below the course split', () => {
+    // 5100mm × 3229–2400mm raked → course split at 2400 (lower wall height)
+    const wall = makeWall({
+      length_mm: 5100,
+      height_mm: 3229,
+      height_right_mm: 2400,
+      profile: WALL_PROFILES.RAKED,
+    });
+    const layout = calculateWallLayout(wall);
+    expect(layout.isMultiCourse).toBe(true);
+    expect(layout.courses[0].height).toBe(2400);
+
+    const courseSplit = layout.courses[0].height;
+
+    // Every C2 panel must have at least one edge with positive height
+    const c2Panels = layout.panels.filter(p => p.course === 1);
+    for (const panel of c2Panels) {
+      const wallHL = layout.heightAt(panel.x);
+      const wallHR = layout.heightAt(panel.x + panel.width);
+      // At least one edge must be above the course split
+      expect(Math.max(wallHL, wallHR)).toBeGreaterThan(courseSplit);
+    }
+  });
+
+  it('raked: C1 panel heights are clipped to actual wall height', () => {
+    // 5100mm × 3229–2400mm raked → course split at 2400
+    const wall = makeWall({
+      length_mm: 5100,
+      height_mm: 3229,
+      height_right_mm: 2400,
+      profile: WALL_PROFILES.RAKED,
+    });
+    const layout = calculateWallLayout(wall);
+    const courseSplit = layout.courses[0].height;
+
+    const c1Panels = layout.panels.filter(p => p.course === 0);
+    for (const panel of c1Panels) {
+      const wallHL = Math.round(layout.heightAt(panel.x));
+      const wallHR = Math.round(layout.heightAt(panel.x + panel.width));
+      // Panel heightLeft should not exceed the actual wall height at that edge
+      expect(panel.heightLeft).toBeLessThanOrEqual(wallHL);
+      expect(panel.heightRight).toBeLessThanOrEqual(wallHR);
+      // Panel heights should also not exceed course height
+      expect(panel.heightLeft).toBeLessThanOrEqual(courseSplit);
+      expect(panel.heightRight).toBeLessThanOrEqual(courseSplit);
+    }
+  });
+
+  it('raked: C2 panels have non-negative heights at both edges', () => {
+    const wall = makeWall({
+      length_mm: 9740,
+      height_mm: 4000,
+      height_right_mm: 2600,
+      profile: WALL_PROFILES.RAKED,
+    });
+    const layout = calculateWallLayout(wall);
+    expect(layout.isMultiCourse).toBe(true);
+
+    for (const panel of layout.panels) {
+      expect(panel.heightLeft).toBeGreaterThanOrEqual(0);
+      expect(panel.heightRight).toBeGreaterThanOrEqual(0);
+      // At least one edge must be positive (zero-height panels are filtered)
+      expect(Math.max(panel.heightLeft, panel.heightRight)).toBeGreaterThan(0);
+    }
+  });
+
+  it('raked: no panels have heightLeft > course height or heightRight > course height', () => {
+    const wall = makeWall({
+      length_mm: 5100,
+      height_mm: 3229,
+      height_right_mm: 2400,
+      profile: WALL_PROFILES.RAKED,
+    });
+    const layout = calculateWallLayout(wall);
+
+    for (const panel of layout.panels) {
+      const course = layout.courses[panel.course];
+      expect(panel.heightLeft).toBeLessThanOrEqual(course.height);
+      expect(panel.heightRight).toBeLessThanOrEqual(course.height);
+    }
+  });
+
+  it('gable: course split at base height, no C2 slivers at edges', () => {
+    // Base 2700mm, peak 4800mm → course split at 2700 (base height)
+    const wall = makeWall({
+      length_mm: 7200,
+      height_mm: 2700,
+      peak_height_mm: 4800,
+      profile: WALL_PROFILES.GABLE,
+    });
+    const layout = calculateWallLayout(wall);
+    expect(layout.isMultiCourse).toBe(true);
+    expect(layout.courses[0].height).toBe(2700);
+    expect(layout.courses[0].sheetHeight).toBe(2745);
+
+    const courseSplit = layout.courses[0].height;
+
+    // C2 panels should only exist where wall is above the base height
+    const c2Panels = layout.panels.filter(p => p.course === 1);
+    for (const panel of c2Panels) {
+      const wallHL = layout.heightAt(panel.x);
+      const wallHR = layout.heightAt(panel.x + panel.width);
+      expect(Math.max(wallHL, wallHR)).toBeGreaterThan(courseSplit);
+    }
+
+    // C1 panels should not exceed base height
+    const c1Panels = layout.panels.filter(p => p.course === 0);
+    for (const panel of c1Panels) {
+      expect(panel.heightLeft).toBeLessThanOrEqual(courseSplit);
+      expect(panel.heightRight).toBeLessThanOrEqual(courseSplit);
+    }
+  });
+
+  it('gable: hspline position matches base height, not stock sheet height', () => {
+    const wall = makeWall({
+      length_mm: 7200,
+      height_mm: 2700,
+      peak_height_mm: 4800,
+      profile: WALL_PROFILES.GABLE,
+    });
+    const layout = calculateWallLayout(wall);
+    expect(layout.isMultiCourse).toBe(true);
+
+    // Course join (C2 start) should be at base height
+    expect(layout.courses[1].y).toBe(2700);
+    // Sheet height should be the covering stock sheet
+    expect(layout.courses[0].sheetHeight).toBe(2745);
+  });
+});

--- a/devpro-wall-builder/src/utils/labelClash.test.js
+++ b/devpro-wall-builder/src/utils/labelClash.test.js
@@ -1,0 +1,304 @@
+import { describe, it, expect } from 'vitest';
+import { calculateWallLayout } from './calculator.js';
+import { WALL_PROFILES, OPENING_TYPES } from './constants.js';
+
+// ── Helpers ──
+
+function makeWall(overrides = {}) {
+  return {
+    length_mm: 9740,
+    height_mm: 2440,
+    profile: WALL_PROFILES.STANDARD,
+    deduction_left_mm: 0,
+    deduction_right_mm: 0,
+    openings: [],
+    ...overrides,
+  };
+}
+
+/**
+ * Compute label positions exactly as the elevation components do.
+ * Returns { x, y, width, height, label } for each panel label.
+ */
+function computeLabelPositions(layout) {
+  const { panels, courses, isMultiCourse, height, heightAt } = layout;
+  const basePanels = panels.filter(p => (p.course ?? 0) === 0);
+  const posMap = new Map(basePanels.map((p, idx) => [p.x, idx]));
+
+  return panels.map(panel => {
+    const courseIdx = panel.course ?? 0;
+    const course = courses?.[courseIdx];
+    const cY = course?.y ?? 0;
+    const cTop = cY + (course?.height ?? height);
+    const centerX = panel.x + panel.width / 2;
+
+    // Vertical center of this course region at the panel's x
+    const absH = heightAt ? heightAt(centerX) : height;
+    const courseMidTop = Math.min(absH, cTop);
+    const courseMidY = (cY + courseMidTop) / 2; // mm from wall bottom
+
+    const posIdx = posMap.get(panel.x) ?? 0;
+    const label = isMultiCourse ? `P${posIdx + 1}·C${courseIdx + 1}` : `P${posIdx + 1}`;
+
+    // Approximate label dimensions in mm (based on font size ~10px at typical scale)
+    // At scale ≈ 0.11 (1100px / 9740mm), 10px text ≈ 90mm width for "P1·C1"
+    const approxCharWidthMm = 15; // ~15mm per character at typical scale
+    const approxHeightMm = 30;    // ~30mm text height at typical scale
+    const labelW = label.length * approxCharWidthMm;
+    const labelH = approxHeightMm;
+
+    return {
+      x: centerX,
+      y: courseMidY,
+      width: labelW,
+      height: labelH,
+      label,
+      panelWidth: panel.width,
+      courseHeight: course?.height ?? height,
+      courseIdx,
+    };
+  });
+}
+
+function rectsOverlap(a, b) {
+  const aL = a.x - a.width / 2;
+  const aR = a.x + a.width / 2;
+  const aT = a.y - a.height / 2;
+  const aB = a.y + a.height / 2;
+  const bL = b.x - b.width / 2;
+  const bR = b.x + b.width / 2;
+  const bT = b.y - b.height / 2;
+  const bB = b.y + b.height / 2;
+  return aL < bR && aR > bL && aT < bB && aB > bT;
+}
+
+function checkLabelClashes(layout, testName) {
+  const labels = computeLabelPositions(layout);
+  const clashes = [];
+
+  for (let i = 0; i < labels.length; i++) {
+    for (let j = i + 1; j < labels.length; j++) {
+      if (rectsOverlap(labels[i], labels[j])) {
+        clashes.push({ a: labels[i].label, b: labels[j].label });
+      }
+    }
+  }
+
+  return { labels, clashes };
+}
+
+function checkLabelsWithinCourse(layout) {
+  const labels = computeLabelPositions(layout);
+  const issues = [];
+
+  for (const lbl of labels) {
+    // Check if label text height fits within the course region
+    if (lbl.courseHeight < lbl.height) {
+      issues.push({
+        label: lbl.label,
+        courseHeight: lbl.courseHeight,
+        labelHeight: lbl.height,
+        reason: 'label taller than course height',
+      });
+    }
+  }
+
+  return issues;
+}
+
+// ── Test cases ──
+
+describe('Label clash detection — multi-course elevations', () => {
+
+  it('Test 1: basic 2-course, 4 panels — no clashes', () => {
+    const layout = calculateWallLayout(makeWall({ length_mm: 4815, height_mm: 4000 }));
+    const { clashes } = checkLabelClashes(layout);
+    expect(clashes).toEqual([]);
+  });
+
+  it('Test 2: 2-course, ~8 panels — no clashes', () => {
+    const layout = calculateWallLayout(makeWall({ length_mm: 9740, height_mm: 4000 }));
+    const { clashes } = checkLabelClashes(layout);
+    expect(clashes).toEqual([]);
+  });
+
+  it('Test 3: 2-course, 2 narrow panels — check for clashes', () => {
+    const layout = calculateWallLayout(makeWall({ length_mm: 2410, height_mm: 4000 }));
+    const { labels, clashes } = checkLabelClashes(layout);
+
+    // With narrow panels, labels may clash horizontally — log any issues
+    if (clashes.length > 0) {
+      console.warn(`Test 3 clashes: ${clashes.map(c => `${c.a} ↔ ${c.b}`).join(', ')}`);
+    }
+    // At minimum, labels within the same course should not clash
+    const sameCourseClashes = clashes.filter(c => {
+      const la = labels.find(l => l.label === c.a);
+      const lb = labels.find(l => l.label === c.b);
+      return la.courseIdx === lb.courseIdx;
+    });
+    expect(sameCourseClashes).toEqual([]);
+  });
+
+  it('Test 4: opening in bottom course only — no clashes', () => {
+    const layout = calculateWallLayout(makeWall({
+      length_mm: 9740,
+      height_mm: 4000,
+      openings: [{
+        ref: 'W1', type: OPENING_TYPES.WINDOW,
+        width_mm: 1200, height_mm: 1200, sill_mm: 500,
+        position_from_left_mm: 4000,
+      }],
+    }));
+    const { clashes } = checkLabelClashes(layout);
+    expect(clashes).toEqual([]);
+  });
+
+  it('Test 5: door spanning both courses — no clashes', () => {
+    const layout = calculateWallLayout(makeWall({
+      length_mm: 9740,
+      height_mm: 4000,
+      openings: [{
+        ref: 'D1', type: OPENING_TYPES.DOOR,
+        width_mm: 900, height_mm: 3200, sill_mm: 0,
+        position_from_left_mm: 4000,
+      }],
+    }));
+    const { clashes } = checkLabelClashes(layout);
+    expect(clashes).toEqual([]);
+  });
+
+  it('Test 6: very short top course (~200mm) — labels may not fit vertically', () => {
+    // 5500mm wall → bottom 3050 + top 2450, actually fits
+    // Use 3300mm → bottom 2745 + top 555mm
+    const layout = calculateWallLayout(makeWall({ length_mm: 9740, height_mm: 3300 }));
+    if (!layout.isMultiCourse) return; // skip if single course
+
+    const issues = checkLabelsWithinCourse(layout);
+    if (issues.length > 0) {
+      console.warn('Test 6 — labels that don\'t fit vertically:', issues);
+    }
+    // No same-course clashes
+    const { clashes, labels } = checkLabelClashes(layout);
+    const sameCourseClashes = clashes.filter(c => {
+      const la = labels.find(l => l.label === c.a);
+      const lb = labels.find(l => l.label === c.b);
+      return la.courseIdx === lb.courseIdx;
+    });
+    expect(sameCourseClashes).toEqual([]);
+  });
+
+  it('Test 7: 3-course wall — no same-course clashes', () => {
+    const layout = calculateWallLayout(makeWall({ length_mm: 9740, height_mm: 7000 }));
+    expect(layout.courses.length).toBeGreaterThanOrEqual(3);
+    const { clashes, labels } = checkLabelClashes(layout);
+    const sameCourseClashes = clashes.filter(c => {
+      const la = labels.find(l => l.label === c.a);
+      const lb = labels.find(l => l.label === c.b);
+      return la.courseIdx === lb.courseIdx;
+    });
+    expect(sameCourseClashes).toEqual([]);
+  });
+
+  it('Test 8: raked 2-course — no same-course clashes', () => {
+    const layout = calculateWallLayout(makeWall({
+      length_mm: 9740,
+      height_mm: 4000,
+      height_right_mm: 3200,
+      profile: WALL_PROFILES.RAKED,
+    }));
+    const { clashes, labels } = checkLabelClashes(layout);
+    const sameCourseClashes = clashes.filter(c => {
+      const la = labels.find(l => l.label === c.a);
+      const lb = labels.find(l => l.label === c.b);
+      return la.courseIdx === lb.courseIdx;
+    });
+    expect(sameCourseClashes).toEqual([]);
+  });
+
+  it('Test 9: gable 2-course — no same-course clashes', () => {
+    const layout = calculateWallLayout(makeWall({
+      length_mm: 9740,
+      height_mm: 4000,
+      peak_height_mm: 4500,
+      profile: WALL_PROFILES.GABLE,
+    }));
+    const { clashes, labels } = checkLabelClashes(layout);
+    const sameCourseClashes = clashes.filter(c => {
+      const la = labels.find(l => l.label === c.a);
+      const lb = labels.find(l => l.label === c.b);
+      return la.courseIdx === lb.courseIdx;
+    });
+    expect(sameCourseClashes).toEqual([]);
+  });
+
+  it('Test 10: 2 windows close together — no same-course clashes', () => {
+    const layout = calculateWallLayout(makeWall({
+      length_mm: 4815,
+      height_mm: 4000,
+      openings: [
+        {
+          ref: 'W1', type: OPENING_TYPES.WINDOW,
+          width_mm: 900, height_mm: 1000, sill_mm: 800,
+          position_from_left_mm: 1200,
+        },
+        {
+          ref: 'W2', type: OPENING_TYPES.WINDOW,
+          width_mm: 900, height_mm: 1000, sill_mm: 800,
+          position_from_left_mm: 2600,
+        },
+      ],
+    }));
+    const { clashes, labels } = checkLabelClashes(layout);
+    const sameCourseClashes = clashes.filter(c => {
+      const la = labels.find(l => l.label === c.a);
+      const lb = labels.find(l => l.label === c.b);
+      return la.courseIdx === lb.courseIdx;
+    });
+    expect(sameCourseClashes).toEqual([]);
+  });
+});
+
+describe('Label positioning — single course baseline', () => {
+  it('single-course wall labels do not clash', () => {
+    const layout = calculateWallLayout(makeWall({ length_mm: 9740, height_mm: 2440 }));
+    const { clashes } = checkLabelClashes(layout);
+    expect(clashes).toEqual([]);
+  });
+
+  it('single-course labels use P1, P2 format (no course suffix)', () => {
+    const layout = calculateWallLayout(makeWall({ length_mm: 4815, height_mm: 2440 }));
+    const labels = computeLabelPositions(layout);
+    for (const lbl of labels) {
+      expect(lbl.label).toMatch(/^P\d+$/);
+    }
+  });
+
+  it('multi-course labels use P1·C1 format', () => {
+    const layout = calculateWallLayout(makeWall({ length_mm: 4815, height_mm: 4000 }));
+    const labels = computeLabelPositions(layout);
+    for (const lbl of labels) {
+      expect(lbl.label).toMatch(/^P\d+·C\d+$/);
+    }
+  });
+});
+
+describe('Label vertical fit', () => {
+  it('all labels fit vertically in their course for standard 2-course', () => {
+    const layout = calculateWallLayout(makeWall({ length_mm: 9740, height_mm: 4000 }));
+    const issues = checkLabelsWithinCourse(layout);
+    expect(issues).toEqual([]);
+  });
+
+  it('reports labels that do not fit in very short courses', () => {
+    // 3080mm wall → bottom 2745 + top 335mm — top course very short
+    const layout = calculateWallLayout(makeWall({ length_mm: 9740, height_mm: 3080 }));
+    if (!layout.isMultiCourse) return;
+
+    const topCourse = layout.courses[layout.courses.length - 1];
+    if (topCourse.height < 30) {
+      // Label won't fit — this is expected, just verify we detect it
+      const issues = checkLabelsWithinCourse(layout);
+      expect(issues.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/devpro-wall-builder/src/utils/magboardOptimizer.js
+++ b/devpro-wall-builder/src/utils/magboardOptimizer.js
@@ -39,29 +39,13 @@ export function extractMagboardPieces(layout, wallName = '') {
   } = layout;
 
   // ── Panel face sheets ──
-  // Each panel uses its own sheetHeight (per-panel assignment from calculator).
-  // Multi-course panels need 2 sheets per course; single-course panels need 2 sheets total.
+  // Each panel in the array is already course-specific (tagged with panel.course).
+  // 2 sheets per panel (front + back).
   for (const panel of panels) {
-    if (panel.isMultiCourse && courses.length > 1) {
-      for (const course of courses) {
-        // 2 sheets per panel per course (front + back)
-        panelSheets.push({
-          sheetHeight: course.sheetHeight,
-          label: `P${panel.index + 1} C${courses.indexOf(course) + 1}`,
-          wallName,
-        });
-        panelSheets.push({
-          sheetHeight: course.sheetHeight,
-          label: `P${panel.index + 1} C${courses.indexOf(course) + 1}`,
-          wallName,
-        });
-      }
-    } else {
-      // Single-course panel: use per-panel sheetHeight (front + back)
-      const sheetH = panel.sheetHeight || courses?.[0]?.sheetHeight || height;
-      panelSheets.push({ sheetHeight: sheetH, label: `P${panel.index + 1}`, wallName });
-      panelSheets.push({ sheetHeight: sheetH, label: `P${panel.index + 1}`, wallName });
-    }
+    const sheetH = panel.sheetHeight || courses?.[panel.course ?? 0]?.sheetHeight || height;
+    const courseLabel = isMultiCourse ? ` C${(panel.course ?? 0) + 1}` : '';
+    panelSheets.push({ sheetHeight: sheetH, label: `P${panel.index + 1}${courseLabel}`, wallName });
+    panelSheets.push({ sheetHeight: sheetH, label: `P${panel.index + 1}${courseLabel}`, wallName });
   }
 
   // ── Lintels: 2 magboard pieces each (EPS area above timber beam) ──
@@ -96,12 +80,14 @@ export function extractMagboardPieces(layout, wallName = '') {
 
   // ── Vertical splines: 2 magboard pieces each ──
   // Track which joints have vertical splines (needed for horizontal spline sizing)
-  const jointHasSpline = new Array(panels.length - 1).fill(false);
+  // Use course 0 panels for joint detection (x-positions are identical across courses)
+  const basePanels = panels.filter(p => (p.course ?? 0) === 0);
+  const jointHasSpline = new Array(basePanels.length - 1).fill(false);
   const splineH = height - BOTTOM_PLATE - TOP_PLATE * 2 - 10;
   if (splineH > 0) {
     // Joint splines
-    for (let i = 0; i < panels.length - 1; i++) {
-      const panel = panels[i];
+    for (let i = 0; i < basePanels.length - 1; i++) {
+      const panel = basePanels[i];
       const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
       const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
       const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
@@ -112,7 +98,7 @@ export function extractMagboardPieces(layout, wallName = '') {
             width: SPLINE_WIDTH,
             height: splineH,
             type: 'spline',
-            label: `Spline P${panels[i].index + 1}/P${panels[i + 1].index + 1}`,
+            label: `Spline P${basePanels[i].index + 1}/P${basePanels[i + 1].index + 1}`,
             wallName,
           });
         }
@@ -134,15 +120,16 @@ export function extractMagboardPieces(layout, wallName = '') {
   // Width = distance between inner edges of adjacent vertical splines, less 10mm each end.
   // First/last panels (or joints without a vertical spline) use the vertical timber
   // edge (panel edge) as the boundary, still less 10mm clearance.
+  // Use basePanels (course 0) for x-positions since they are the same across courses.
   if (isMultiCourse && courses.length > 1) {
     for (let ci = 0; ci < courses.length - 1; ci++) {
-      for (let pi = 0; pi < panels.length; pi++) {
-        const panel = panels[pi];
+      for (let pi = 0; pi < basePanels.length; pi++) {
+        const panel = basePanels[pi];
 
         // Left boundary
         let leftEdge;
         if (pi > 0 && jointHasSpline[pi - 1]) {
-          const gapCentre = panels[pi - 1].x + panels[pi - 1].width + PANEL_GAP / 2;
+          const gapCentre = basePanels[pi - 1].x + basePanels[pi - 1].width + PANEL_GAP / 2;
           leftEdge = gapCentre + SPLINE_WIDTH / 2;
         } else {
           leftEdge = panel.x + BOTTOM_PLATE;
@@ -150,7 +137,7 @@ export function extractMagboardPieces(layout, wallName = '') {
 
         // Right boundary
         let rightEdge;
-        if (pi < panels.length - 1 && jointHasSpline[pi]) {
+        if (pi < basePanels.length - 1 && jointHasSpline[pi]) {
           const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
           rightEdge = gapCentre - SPLINE_WIDTH / 2;
         } else {

--- a/devpro-wall-builder/src/utils/magboardOptimizer.test.js
+++ b/devpro-wall-builder/src/utils/magboardOptimizer.test.js
@@ -129,7 +129,9 @@ describe('extractMagboardPieces', () => {
 
     expect(layout.isMultiCourse).toBe(true);
     const hsplines = cutPieces.filter(p => p.type === 'hspline');
-    const expectedCount = layout.panels.length * (layout.courses.length - 1) * 2;
+    // Panels per course (x-positions); layout.panels now includes all courses
+    const panelsPerCourse = layout.panels.filter(p => p.course === 0).length;
+    const expectedCount = panelsPerCourse * (layout.courses.length - 1) * 2;
     expect(hsplines.length).toBe(expectedCount);
 
     // Each hspline height should be SPLINE_WIDTH (146mm)
@@ -145,19 +147,20 @@ describe('extractMagboardPieces', () => {
     const { cutPieces } = extractMagboardPieces(layout, 'W1');
 
     expect(layout.isMultiCourse).toBe(true);
-    expect(layout.panels.length).toBeGreaterThanOrEqual(3);
+    // Use course 0 panels for x-position checks (same positions across courses)
+    const basePanels = layout.panels.filter(p => (p.course ?? 0) === 0);
+    expect(basePanels.length).toBeGreaterThanOrEqual(3);
 
     const hsplines = cutPieces.filter(p => p.type === 'hspline');
     const SPLINE_W = 146;
     const CLEARANCE = 10;
-    const panels = layout.panels;
 
     // Check the middle panel (index 1) — has vertical splines on both sides
     // Left spline inner edge = gap_centre + SPLINE_W/2
     // Right spline inner edge = gap_centre - SPLINE_W/2
     // hspline width = rightEdge - leftEdge - 20
-    const midPanel = panels[1];
-    const leftGap = panels[0].x + panels[0].width + 5 / 2;
+    const midPanel = basePanels[1];
+    const leftGap = basePanels[0].x + basePanels[0].width + 5 / 2;
     const rightGap = midPanel.x + midPanel.width + 5 / 2;
     const expectedMidWidth = (rightGap - SPLINE_W / 2) - (leftGap + SPLINE_W / 2) - 2 * CLEARANCE;
 
@@ -167,7 +170,7 @@ describe('extractMagboardPieces', () => {
 
     // First panel — left boundary is panel.x + BOTTOM_PLATE (past vertical timber), right is spline inner edge
     const BOTTOM_PLATE = 45;
-    const firstPanel = panels[0];
+    const firstPanel = basePanels[0];
     const firstRightGap = firstPanel.x + firstPanel.width + 5 / 2;
     const expectedFirstWidth = (firstRightGap - SPLINE_W / 2) - (firstPanel.x + BOTTOM_PLATE) - 2 * CLEARANCE;
     const firstHsplines = hsplines.filter(h => h.label.includes(`P${firstPanel.index + 1}`));
@@ -177,8 +180,8 @@ describe('extractMagboardPieces', () => {
     expect(firstHsplines[0].width).toBeLessThan(firstPanel.width);
 
     // Last panel — left is spline inner edge, right boundary is panel edge - BOTTOM_PLATE (past vertical timber)
-    const lastPanel = panels[panels.length - 1];
-    const lastLeftGap = panels[panels.length - 2].x + panels[panels.length - 2].width + 5 / 2;
+    const lastPanel = basePanels[basePanels.length - 1];
+    const lastLeftGap = basePanels[basePanels.length - 2].x + basePanels[basePanels.length - 2].width + 5 / 2;
     const expectedLastWidth = (lastPanel.x + lastPanel.width - BOTTOM_PLATE) - (lastLeftGap + SPLINE_W / 2) - 2 * CLEARANCE;
     const lastHsplines = hsplines.filter(h => h.label.includes(`P${lastPanel.index + 1}`));
     expect(lastHsplines[0].width).toBeCloseTo(expectedLastWidth, 0);
@@ -195,13 +198,8 @@ describe('extractMagboardPieces', () => {
     expect(layout.isMultiCourse).toBe(true);
     expect(layout.courses.length).toBe(2);
 
-    // Multi-course panels get 2 sheets per course
-    const multiCoursePanels = layout.panels.filter(p => p.isMultiCourse);
-    const singleCoursePanels = layout.panels.filter(p => !p.isMultiCourse);
-
-    const expectedSheets =
-      multiCoursePanels.length * layout.courses.length * 2 +
-      singleCoursePanels.length * 2;
+    // Each panel in layout.panels is now course-specific → 2 sheets each (front + back)
+    const expectedSheets = layout.panels.length * 2;
 
     expect(panelSheets.length).toBe(expectedSheets);
   });


### PR DESCRIPTION
## Summary
- **Course split logic**: Raked/gable walls now split at actual wall height (not stock sheet height), eliminating inverted polygons and sliver panels at edges
- **Panel replication**: Panels replicated across courses with course-specific heights, opening intersection checks, and proper clipping
- **Rendering fixes**: Panel polygon vertices clamped to course bounds in WallDrawing; hspline y-position corrected in FramingElevation and EpsElevation
- **UI updates**: WallSummary uses course-aware naming (P{pos}·C{course}); magboardOptimizer uses basePanels for splines/joints

## Test plan
- [x] 104 tests passing (calculator, label clash, magboard optimizer, wall snap)
- [ ] Visual check: gable wall elevation — no C2 slivers at edges, peak panel clipped at course boundary
- [ ] Visual check: raked wall elevation — panels follow slope, no inverted polygons
- [ ] Visual check: framing/EPS plans — hsplines at correct y-position (wall base height, not stock sheet height)

🤖 Generated with [Claude Code](https://claude.com/claude-code)