### PR TITLE
Add 3D viewer interactions and DXF export for all plan types

### DIFF
--- a/devpro-wall-builder/package-lock.json
+++ b/devpro-wall-builder/package-lock.json
@@ -11,6 +11,7 @@
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
         "camera-controls": "^3.1.2",
+        "dxf-writer": "^1.18.4",
         "jszip": "^3.10.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -2196,6 +2197,12 @@
       "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
       "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/dxf-writer": {
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/dxf-writer/-/dxf-writer-1.18.4.tgz",
+      "integrity": "sha512-JdLOyP+1UyeB30yPowJLJKK0bPROq/dX+QTWcLSplQoepcyo/YMlU0Z27T7mIPxgwiPb+CQWwUIlbcRRfns+ng==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.307",

--- a/devpro-wall-builder/package.json
+++ b/devpro-wall-builder/package.json
@@ -15,6 +15,7 @@
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
     "camera-controls": "^3.1.2",
+    "dxf-writer": "^1.18.4",
     "jszip": "^3.10.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/devpro-wall-builder/src/components/EpsCutPlans.jsx
+++ b/devpro-wall-builder/src/components/EpsCutPlans.jsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { BOTTOM_PLATE, TOP_PLATE, PANEL_GAP } from '../utils/constants.js';
 import PrintButton from './PrintButton.jsx';
+import ExportDxfButton from './ExportDxfButton.jsx';
 
 const SPLINE_WIDTH = 146;
 const HALF_SPLINE = SPLINE_WIDTH / 2;
@@ -85,7 +86,7 @@ const cardStyle = {
   margin: 6,
 };
 
-export default function EpsCutPlans({ layout, wallName }) {
+export default function EpsCutPlans({ layout, wallName, projectName }) {
   const sectionRef = useRef(null);
   if (!layout) return null;
 
@@ -275,7 +276,10 @@ export default function EpsCutPlans({ layout, wallName }) {
             <h3 style={{ margin: 0, fontSize: 16, color: '#333' }}>
               EPS Cut Plans — 142mm thick {wallName && `— ${wallName}`}
             </h3>
-            <PrintButton sectionRef={sectionRef} label="EPS Cuts" />
+            <div style={{ display: 'flex', gap: 4 }}>
+              <PrintButton sectionRef={sectionRef} label="EPS Cuts" projectName={projectName} wallName={wallName} />
+              <ExportDxfButton layout={layout} wallName={wallName} projectName={projectName} planType="eps-plans" />
+            </div>
           </div>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
             {pieces.map((piece, i) => (

--- a/devpro-wall-builder/src/components/EpsElevation.jsx
+++ b/devpro-wall-builder/src/components/EpsElevation.jsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { COLORS, WINDOW_OVERHANG, BOTTOM_PLATE, TOP_PLATE, PANEL_GAP, SPLINE_WIDTH, HSPLINE_CLEARANCE, buildHSplineSegments } from '../utils/constants.js';
 import PrintButton from './PrintButton.jsx';
+import ExportDxfButton from './ExportDxfButton.jsx';
 
 const HALF_SPLINE = SPLINE_WIDTH / 2;
 const EPS_INSET = 10; // mm recess from framing
@@ -15,7 +16,7 @@ const SPLINE_EPS_FILL = '#CCE6FF';
 const SPLINE_EPS_STROKE = '#6AACE6';
 const MAGBOARD = 10; // mm each face
 
-export default function EpsElevation({ layout, wallName }) {
+export default function EpsElevation({ layout, wallName, projectName }) {
   const sectionRef = useRef(null);
   const clipId = useRef(`eps-clip-${Math.random().toString(36).slice(2, 8)}`).current;
   if (!layout) return null;
@@ -185,8 +186,9 @@ export default function EpsElevation({ layout, wallName }) {
 
   return (
     <div ref={sectionRef} data-print-section style={{ overflowX: 'auto', background: '#fff', borderRadius: 8, border: '1px solid #ddd', marginTop: 16 }}>
-      <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '8px 12px 0' }}>
-        <PrintButton sectionRef={sectionRef} label="EPS" />
+      <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '8px 12px 0', gap: 4 }}>
+        <PrintButton sectionRef={sectionRef} label="EPS" projectName={projectName} wallName={wallName} />
+        <ExportDxfButton layout={layout} wallName={wallName} projectName={projectName} planType="eps-elevation" />
       </div>
       <svg
         width={svgWidth}

--- a/devpro-wall-builder/src/components/ExportDxfButton.jsx
+++ b/devpro-wall-builder/src/components/ExportDxfButton.jsx
@@ -1,0 +1,52 @@
+import { useCallback } from 'react';
+import { exportEpsElevationDxf } from '../utils/epsElevationDxf.js';
+import { exportFramingElevationDxf } from '../utils/framingElevationDxf.js';
+import { exportEpsPlanDxf } from '../utils/epsPlanDxf.js';
+import { exportExternalElevationDxf } from '../utils/externalElevationDxf.js';
+import { exportPanelPlansDxf } from '../utils/panelPlansDxf.js';
+
+const EXPORTERS = {
+  'external-elevation': exportExternalElevationDxf,
+  'eps-elevation': exportEpsElevationDxf,
+  'framing': exportFramingElevationDxf,
+  'eps-plans': exportEpsPlanDxf,
+  'panel-plans': exportPanelPlansDxf,
+};
+
+const LABELS = {
+  'external-elevation': 'Elevation',
+  'eps-elevation': 'EPS Elevation',
+  'framing': 'Framing',
+  'eps-plans': 'EPS Cuts',
+  'panel-plans': 'Panel Plans',
+};
+
+export default function ExportDxfButton({ layout, wallName, projectName, planType }) {
+  const handleExport = useCallback(() => {
+    const exporter = EXPORTERS[planType];
+    if (exporter && layout) exporter(layout, wallName, projectName);
+  }, [layout, wallName, projectName, planType]);
+
+  if (!layout) return null;
+
+  return (
+    <button onClick={handleExport} style={styles.btn} className="no-print">
+      DXF — {LABELS[planType] || planType}
+    </button>
+  );
+}
+
+const styles = {
+  btn: {
+    padding: '6px 16px',
+    background: '#6B8E23',
+    color: '#fff',
+    border: 'none',
+    borderRadius: 4,
+    cursor: 'pointer',
+    fontSize: 13,
+    fontWeight: 600,
+    flexShrink: 0,
+    marginLeft: 6,
+  },
+};

--- a/devpro-wall-builder/src/components/FramingElevation.jsx
+++ b/devpro-wall-builder/src/components/FramingElevation.jsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { COLORS, WINDOW_OVERHANG, BOTTOM_PLATE, TOP_PLATE, PANEL_GAP, PANEL_PITCH, SPLINE_WIDTH, HSPLINE_CLEARANCE, buildHSplineSegments } from '../utils/constants.js';
 import PrintButton from './PrintButton.jsx';
+import ExportDxfButton from './ExportDxfButton.jsx';
 
 const HALF_SPLINE = SPLINE_WIDTH / 2; // 73mm each side of centre
 
@@ -13,7 +14,7 @@ const STROKE_COLOR = '#333';
 const LABEL_COLOR = '#555';
 const PLATE_COLOR = '#888';
 
-export default function FramingElevation({ layout, wallName }) {
+export default function FramingElevation({ layout, wallName, projectName }) {
   const sectionRef = useRef(null);
   if (!layout) return null;
 
@@ -58,8 +59,9 @@ export default function FramingElevation({ layout, wallName }) {
 
   return (
     <div ref={sectionRef} data-print-section style={{ overflowX: 'auto', background: '#fff', borderRadius: 8, border: '1px solid #ddd', marginTop: 16 }}>
-      <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '8px 12px 0' }}>
-        <PrintButton sectionRef={sectionRef} label="Framing" />
+      <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '8px 12px 0', gap: 4 }}>
+        <PrintButton sectionRef={sectionRef} label="Framing" projectName={projectName} wallName={wallName} />
+        <ExportDxfButton layout={layout} wallName={wallName} projectName={projectName} planType="framing" />
       </div>
       <svg
         width={svgWidth}

--- a/devpro-wall-builder/src/components/Offcuts.jsx
+++ b/devpro-wall-builder/src/components/Offcuts.jsx
@@ -232,7 +232,7 @@ const cardStyle = {
   margin: 4,
 };
 
-export default function Offcuts({ layout, wallName }) {
+export default function Offcuts({ layout, wallName, projectName }) {
   const sectionRef = useRef(null);
   if (!layout) return null;
 
@@ -248,7 +248,7 @@ export default function Offcuts({ layout, wallName }) {
         <h3 style={{ margin: 0, fontSize: 16, color: '#333' }}>
           Offcuts {wallName && `— ${wallName}`}
         </h3>
-        <PrintButton sectionRef={sectionRef} label="Offcuts" />
+        <PrintButton sectionRef={sectionRef} label="Offcuts" projectName={projectName} wallName={wallName} />
       </div>
 
       {stockPieces.length > 0 && (

--- a/devpro-wall-builder/src/components/PanelPlans.jsx
+++ b/devpro-wall-builder/src/components/PanelPlans.jsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { WINDOW_OVERHANG, PANEL_GAP, COLORS, OPENING_TYPES, BOTTOM_PLATE, TOP_PLATE } from '../utils/constants.js';
 import PrintButton from './PrintButton.jsx';
+import ExportDxfButton from './ExportDxfButton.jsx';
 
 const SPLINE_WIDTH = 146;
 const HALF_SPLINE = SPLINE_WIDTH / 2;
@@ -594,7 +595,7 @@ const cardStyle = {
   margin: 6,
 };
 
-export default function PanelPlans({ layout, wallName }) {
+export default function PanelPlans({ layout, wallName, projectName }) {
   const sectionRef = useRef(null);
   if (!layout) return null;
 
@@ -689,7 +690,10 @@ export default function PanelPlans({ layout, wallName }) {
           CNC Panel Plans {wallName && `— ${wallName}`}
           {isMultiCourse && ` (${courses.length} courses)`}
         </h3>
-        <PrintButton sectionRef={sectionRef} label="Panel Plans" />
+        <div style={{ display: 'flex', gap: 4 }}>
+          <PrintButton sectionRef={sectionRef} label="Panel Plans" projectName={projectName} wallName={wallName} />
+          <ExportDxfButton layout={layout} wallName={wallName} projectName={projectName} planType="panel-plans" />
+        </div>
       </div>
 
       {isMultiCourse && (

--- a/devpro-wall-builder/src/components/PrintButton.jsx
+++ b/devpro-wall-builder/src/components/PrintButton.jsx
@@ -1,16 +1,24 @@
 import { useCallback } from 'react';
 
-export default function PrintButton({ sectionRef, label }) {
+export default function PrintButton({ sectionRef, label, projectName, wallName }) {
   const handlePrint = useCallback(() => {
+    // Set document title to control the default print filename
+    const prevTitle = document.title;
+    const parts = [projectName, wallName, label].filter(Boolean);
+    if (parts.length > 0) {
+      document.title = parts.join(' ');
+    }
+
     if (!sectionRef?.current) {
       window.print();
-      return;
+    } else {
+      sectionRef.current.setAttribute('data-print-active', 'true');
+      window.print();
+      sectionRef.current.removeAttribute('data-print-active');
     }
-    // Mark this section as the active print target
-    sectionRef.current.setAttribute('data-print-active', 'true');
-    window.print();
-    sectionRef.current.removeAttribute('data-print-active');
-  }, [sectionRef]);
+
+    document.title = prevTitle;
+  }, [sectionRef, projectName, wallName, label]);
 
   return (
     <button onClick={handlePrint} style={styles.btn} className="no-print">

--- a/devpro-wall-builder/src/components/WallDrawing.jsx
+++ b/devpro-wall-builder/src/components/WallDrawing.jsx
@@ -1,11 +1,12 @@
 import { useRef } from 'react';
 import { COLORS, WALL_THICKNESS, PANEL_GAP, WINDOW_OVERHANG } from '../utils/constants.js';
 import PrintButton from './PrintButton.jsx';
+import ExportDxfButton from './ExportDxfButton.jsx';
 
 const MARGIN = { top: 60, right: 40, bottom: 110, left: 60 };
 const MAX_SVG_WIDTH = 1200;
 
-export default function WallDrawing({ layout, wallName }) {
+export default function WallDrawing({ layout, wallName, projectName }) {
   const sectionRef = useRef(null);
   if (!layout) return null;
 
@@ -43,8 +44,9 @@ export default function WallDrawing({ layout, wallName }) {
 
   return (
     <div ref={sectionRef} data-print-section style={{ overflowX: 'auto', background: '#fff', borderRadius: 8, border: '1px solid #ddd' }}>
-      <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '8px 12px 0' }}>
-        <PrintButton sectionRef={sectionRef} label="Elevation" />
+      <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '8px 12px 0', gap: 4 }}>
+        <PrintButton sectionRef={sectionRef} label="Elevation" projectName={projectName} wallName={wallName} />
+        <ExportDxfButton layout={layout} wallName={wallName} projectName={projectName} planType="external-elevation" />
       </div>
       <svg
         width={svgWidth}

--- a/devpro-wall-builder/src/components/WallSummary.jsx
+++ b/devpro-wall-builder/src/components/WallSummary.jsx
@@ -31,7 +31,7 @@ function Row({ label, value, bold }) {
   );
 }
 
-export default function WallSummary({ layout, wallName }) {
+export default function WallSummary({ layout, wallName, projectName }) {
   const sectionRef = useRef(null);
   if (!layout) return null;
 
@@ -167,7 +167,7 @@ export default function WallSummary({ layout, wallName }) {
       {/* Header */}
       <div style={styles.header}>
         <h3 style={styles.title}>Wall Summary — {wallName}</h3>
-        <PrintButton sectionRef={sectionRef} label="Summary" />
+        <PrintButton sectionRef={sectionRef} label="Summary" projectName={projectName} wallName={wallName} />
       </div>
 
       {/* Key metrics */}

--- a/devpro-wall-builder/src/pages/WallBuilderPage.jsx
+++ b/devpro-wall-builder/src/pages/WallBuilderPage.jsx
@@ -99,13 +99,13 @@ export default function WallBuilderPage() {
 
         {layout && (
           <>
-            <WallDrawing layout={layout} wallName={wallName} />
-            <FramingElevation layout={layout} wallName={wallName} />
-            <EpsElevation layout={layout} wallName={wallName} />
-            <PanelPlans layout={layout} wallName={wallName} />
-            <EpsCutPlans layout={layout} wallName={wallName} />
-            <Offcuts layout={layout} wallName={wallName} />
-            <WallSummary layout={layout} wallName={wallName} />
+            <WallDrawing layout={layout} wallName={wallName} projectName={project.name} />
+            <FramingElevation layout={layout} wallName={wallName} projectName={project.name} />
+            <EpsElevation layout={layout} wallName={wallName} projectName={project.name} />
+            <PanelPlans layout={layout} wallName={wallName} projectName={project.name} />
+            <EpsCutPlans layout={layout} wallName={wallName} projectName={project.name} />
+            <Offcuts layout={layout} wallName={wallName} projectName={project.name} />
+            <WallSummary layout={layout} wallName={wallName} projectName={project.name} />
           </>
         )}
       </main>

--- a/devpro-wall-builder/src/utils/dxfExporter.js
+++ b/devpro-wall-builder/src/utils/dxfExporter.js
@@ -1,0 +1,199 @@
+/**
+ * Shared DXF export utilities for DEVPRO Wall Builder.
+ *
+ * All coordinates use real mm values (1:1 scale).
+ * DXF Y-axis: 0 = bottom of wall (floor line), positive = up.
+ * SVG Y-axis was inverted (0 = top), so we flip: dxfY = maxHeight - svgY
+ */
+import Drawing from 'dxf-writer';
+
+// DXF layer definitions
+const LAYERS = {
+  OUTLINE:    { color: Drawing.ACI.WHITE,   line: 'CONTINUOUS' },
+  OPENINGS:   { color: Drawing.ACI.RED,     line: 'CONTINUOUS' },
+  FRAMING:    { color: Drawing.ACI.BLUE,    line: 'DASHED' },
+  EPS:        { color: Drawing.ACI.CYAN,    line: 'CONTINUOUS' },
+  EPS_SPLINE: { color: Drawing.ACI.GREEN,   line: 'CONTINUOUS' },
+  DIMENSIONS: { color: Drawing.ACI.YELLOW,  line: 'CONTINUOUS' },
+  LABELS:     { color: Drawing.ACI.MAGENTA, line: 'CONTINUOUS' },
+};
+
+/**
+ * Create a new DXF Drawing pre-configured with standard layers and mm units.
+ */
+export function createDrawing() {
+  const d = new Drawing();
+  d.setUnits('Millimeters');
+  d.addLineType('DASHED', '_ _ _ ', [5, -5]);
+  for (const [name, def] of Object.entries(LAYERS)) {
+    d.addLayer(name, def.color, def.line);
+  }
+  return d;
+}
+
+/**
+ * Build the wall outline polygon points in DXF coordinates (Y=0 at bottom).
+ * Returns array of [x, y] pairs.
+ */
+export function wallOutlinePoints(layout) {
+  const { grossLength, height, maxHeight, isRaked, heightAt } = layout;
+  const useHeight = maxHeight || height;
+  const pts = [];
+
+  // Bottom edge (left to right)
+  pts.push([0, 0]);
+  pts.push([grossLength, 0]);
+
+  // Right side up to top-right
+  const topRightY = heightAt ? heightAt(grossLength) : height;
+  pts.push([grossLength, topRightY]);
+
+  // Top edge (right to left, follow slope for raked/gable)
+  if (isRaked) {
+    const steps = Math.max(40, Math.round(grossLength / 50));
+    for (let i = steps - 1; i >= 0; i--) {
+      const x = (i / steps) * grossLength;
+      const y = heightAt ? heightAt(x) : height;
+      pts.push([x, y]);
+    }
+  } else {
+    pts.push([0, height]);
+  }
+
+  return pts;
+}
+
+/**
+ * Draw the wall outline polygon on the OUTLINE layer.
+ */
+export function drawWallOutline(d, layout) {
+  d.setActiveLayer('OUTLINE');
+  const pts = wallOutlinePoints(layout);
+  d.drawPolyline(pts.map(([x, y]) => [x, y]), true);
+}
+
+/**
+ * Draw opening rectangles on the OPENINGS layer.
+ * Openings have: x, drawWidth, y (sill from floor), drawHeight.
+ */
+export function drawOpenings(d, openings) {
+  d.setActiveLayer('OPENINGS');
+  for (const op of openings) {
+    const x1 = op.x;
+    const y1 = op.y; // sill height from floor
+    const x2 = op.x + op.drawWidth;
+    const y2 = op.y + op.drawHeight;
+    d.drawPolyline([[x1, y1], [x2, y1], [x2, y2], [x1, y2]], true);
+
+    // X cross lines inside opening
+    d.drawLine(x1, y1, x2, y2);
+    d.drawLine(x2, y1, x1, y2);
+  }
+}
+
+/**
+ * Draw opening labels on LABELS layer.
+ */
+export function drawOpeningLabels(d, openings) {
+  d.setActiveLayer('LABELS');
+  for (const op of openings) {
+    const cx = op.x + op.drawWidth / 2;
+    const cy = op.y + op.drawHeight / 2;
+    d.drawText(cx - 50, cy + 20, 40, 0, op.ref);
+    d.drawText(cx - 80, cy - 30, 30, 0, `${op.width_mm}w x ${op.height_mm}h`);
+  }
+}
+
+/**
+ * Draw overall dimension lines.
+ */
+export function drawDimensions(d, layout) {
+  d.setActiveLayer('DIMENSIONS');
+  const { grossLength, height, maxHeight, isRaked, heightAt, heightLeft, heightRight } = layout;
+  const dimOffset = 150;
+
+  // Bottom width dimension
+  const yDim = -dimOffset;
+  d.drawLine(0, yDim, grossLength, yDim);
+  d.drawLine(0, yDim - 30, 0, yDim + 30);
+  d.drawLine(grossLength, yDim - 30, grossLength, yDim + 30);
+  d.drawText(grossLength / 2 - 100, yDim - 80, 50, 0, `${grossLength} mm`);
+
+  // Left height dimension
+  const leftH = heightLeft || height;
+  const xDim = -dimOffset;
+  d.drawLine(xDim, 0, xDim, leftH);
+  d.drawLine(xDim - 30, 0, xDim + 30, 0);
+  d.drawLine(xDim - 30, leftH, xDim + 30, leftH);
+  d.drawText(xDim - 80, leftH / 2, 50, 90, `${leftH} mm`);
+
+  // Right height dimension (for raked/gable)
+  if (isRaked) {
+    const rightH = heightRight || height;
+    const rxDim = grossLength + dimOffset;
+    d.drawLine(rxDim, 0, rxDim, rightH);
+    d.drawLine(rxDim - 30, 0, rxDim + 30, 0);
+    d.drawLine(rxDim - 30, rightH, rxDim + 30, rightH);
+    d.drawText(rxDim + 40, rightH / 2, 50, 90, `${rightH} mm`);
+  }
+}
+
+/**
+ * Draw running measurement ticks along the bottom.
+ */
+export function drawRunningMeasurement(d, layout) {
+  const { grossLength, panels, footers, deductionLeft, deductionRight } = layout;
+  const basePanels = panels.filter(p => (p.course ?? 0) === 0);
+  d.setActiveLayer('DIMENSIONS');
+
+  const points = new Set([0, grossLength]);
+  if (deductionLeft > 0) points.add(deductionLeft);
+  if (deductionRight > 0) points.add(grossLength - deductionRight);
+  basePanels.forEach(p => points.add(Math.round(p.x + p.width)));
+  footers.forEach(f => points.add(Math.round(f.x + f.width)));
+
+  const tickY = -60;
+  const sorted = [...points].sort((a, b) => a - b);
+  for (const pt of sorted) {
+    d.drawLine(pt, tickY - 20, pt, tickY + 20);
+    d.drawText(pt - 30, tickY - 60, 30, 0, `${pt}`);
+  }
+}
+
+/**
+ * Draw a title block.
+ */
+export function drawTitle(d, title, subtitle, grossLength) {
+  d.setActiveLayer('LABELS');
+  const useHeight = 0; // titles go above the wall
+  d.drawText(grossLength / 2 - 200, useHeight + 250, 60, 0, title);
+  if (subtitle) {
+    d.drawText(grossLength / 2 - 300, useHeight + 170, 40, 0, subtitle);
+  }
+}
+
+/**
+ * Trigger browser download of a DXF file.
+ * In Firefox, set Settings > General > Files and Applications >
+ * "Always ask you where to save files" to get a folder picker.
+ */
+export function downloadDxf(drawing, filename) {
+  const content = drawing.toDxfString();
+  const safeName = filename.endsWith('.dxf') ? filename : `${filename}.dxf`;
+  const blob = new Blob([content], { type: 'application/dxf' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = safeName;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Generate DXF string without downloading (for zip bundling).
+ */
+export function toDxfString(drawing) {
+  return drawing.toDxfString();
+}

--- a/devpro-wall-builder/src/utils/epsElevationDxf.js
+++ b/devpro-wall-builder/src/utils/epsElevationDxf.js
@@ -1,0 +1,393 @@
+/**
+ * DXF export for External (EPS) Elevation Plan.
+ *
+ * Ports the geometry logic from EpsElevation.jsx into DXF entities.
+ * All coordinates in mm, Y=0 at floor line, positive up.
+ */
+import { BOTTOM_PLATE, TOP_PLATE, PANEL_GAP, SPLINE_WIDTH, HSPLINE_CLEARANCE, buildHSplineSegments } from './constants.js';
+import {
+  createDrawing, drawWallOutline, drawOpenings, drawOpeningLabels,
+  drawDimensions, drawRunningMeasurement, drawTitle, downloadDxf,
+} from './dxfExporter.js';
+
+const HALF_SPLINE = SPLINE_WIDTH / 2;
+const EPS_INSET = 10;
+const MAGBOARD = 10;
+
+/**
+ * Build the DXF drawing for an EPS elevation plan.
+ * @param {object} layout - Wall layout from calculateWallLayout()
+ * @param {string} wallName - Wall name for title
+ * @returns {Drawing} dxf-writer Drawing instance
+ */
+export function buildEpsElevationDxf(layout, wallName) {
+  const d = createDrawing();
+  const {
+    grossLength, height, maxHeight, panels, openings, footers, lintels,
+    deductionLeft, deductionRight, isRaked, heightAt, courses, isMultiCourse,
+  } = layout;
+
+  const useHeight = maxHeight || height;
+  // In DXF, Y=0 is floor. heightAt returns height from floor at position x.
+  // SVG had yTopAt(x) = useHeight - heightAt(x), yBottom = useHeight.
+  // DXF: floor = 0, top at x = heightAt(x).
+
+  const hAt = (x) => heightAt ? heightAt(x) : height;
+
+  // Title
+  const titleHeight = hAt(0);
+  drawTitle(d, `${wallName || 'Wall'} — EPS Elevation`,
+    `${grossLength}mm x ${height}mm${isRaked ? ` (max ${useHeight}mm)` : ''} | EPS inset ${EPS_INSET}mm`,
+    grossLength);
+
+  // Wall outline
+  drawWallOutline(d, layout);
+
+  // Corner deductions
+  d.setActiveLayer('OUTLINE');
+  if (deductionLeft > 0) {
+    const topY = hAt(0);
+    d.drawPolyline([[0, 0], [deductionLeft, 0], [deductionLeft, topY], [0, topY]], true);
+  }
+  if (deductionRight > 0) {
+    const x = grossLength - deductionRight;
+    const topY = hAt(grossLength);
+    d.drawPolyline([[x, 0], [grossLength, 0], [grossLength, topY], [x, topY]], true);
+  }
+
+  // ── Build exclusion zones (same as EpsElevation.jsx) ──
+  const basePanels = panels.filter(p => (p.course ?? 0) === 0);
+  const exclusions = [];
+
+  if (deductionLeft > 0) exclusions.push([deductionLeft, deductionLeft + BOTTOM_PLATE]);
+  if (deductionRight > 0) exclusions.push([grossLength - deductionRight - BOTTOM_PLATE, grossLength - deductionRight]);
+
+  for (let i = 0; i < basePanels.length - 1; i++) {
+    const panel = basePanels[i];
+    const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
+    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
+    if (!insideLintel && !insideFooter) {
+      exclusions.push([gapCentre - HALF_SPLINE, gapCentre + HALF_SPLINE]);
+    }
+  }
+
+  for (const op of openings) {
+    const hasSill = op.y > 0;
+    exclusions.push([op.x - BOTTOM_PLATE, op.x]);
+    if (hasSill) exclusions.push([op.x - BOTTOM_PLATE - SPLINE_WIDTH, op.x - BOTTOM_PLATE]);
+    exclusions.push([op.x + op.drawWidth, op.x + op.drawWidth + BOTTOM_PLATE]);
+    if (hasSill) exclusions.push([op.x + op.drawWidth + BOTTOM_PLATE, op.x + op.drawWidth + BOTTOM_PLATE + SPLINE_WIDTH]);
+    exclusions.push([op.x, op.x + op.drawWidth]);
+  }
+
+  for (const p of basePanels) {
+    if (p.type === 'end') exclusions.push([p.x + p.width - BOTTOM_PLATE, p.x + p.width]);
+    if (deductionRight === 0 && Math.abs(p.x + p.width - grossLength) < 1) exclusions.push([grossLength - BOTTOM_PLATE, grossLength]);
+    if (deductionLeft === 0 && Math.abs(p.x) < 1) exclusions.push([0, BOTTOM_PLATE]);
+  }
+
+  for (const l of lintels) exclusions.push([l.x, l.x + l.width]);
+  exclusions.sort((a, b) => a[0] - b[0]);
+
+  const getEpsSegments = (panelLeft, panelRight) => {
+    const clipped = [];
+    for (const [eL, eR] of exclusions) {
+      const cL = Math.max(eL, panelLeft);
+      const cR = Math.min(eR, panelRight);
+      if (cL < cR) clipped.push([cL, cR]);
+    }
+    const merged = [];
+    for (const zone of clipped) {
+      if (merged.length > 0 && zone[0] <= merged[merged.length - 1][1]) {
+        merged[merged.length - 1][1] = Math.max(merged[merged.length - 1][1], zone[1]);
+      } else {
+        merged.push([...zone]);
+      }
+    }
+    const segs = [];
+    let cursor = panelLeft + EPS_INSET;
+    for (const [eL, eR] of merged) {
+      const segRight = eL - EPS_INSET;
+      if (cursor < segRight) segs.push([cursor, segRight]);
+      cursor = eR + EPS_INSET;
+    }
+    const segRight = panelRight - EPS_INSET;
+    if (cursor < segRight) segs.push([cursor, segRight]);
+    return segs;
+  };
+
+  // ── Draw panel outlines and EPS cores ──
+  basePanels.forEach((panel) => {
+    const leftX = panel.x;
+    const rightX = panel.x + panel.width;
+
+    // Panel outline
+    d.setActiveLayer('OUTLINE');
+    if (panel.peakHeight && panel.peakXLocal != null) {
+      const peakX = panel.x + panel.peakXLocal;
+      d.drawLine(leftX, hAt(leftX), peakX, hAt(peakX));
+      d.drawLine(peakX, hAt(peakX), rightX, hAt(rightX));
+    } else {
+      d.drawLine(leftX, hAt(leftX), rightX, hAt(rightX));
+    }
+    d.drawLine(leftX, 0, rightX, 0);
+    d.drawLine(leftX, 0, leftX, hAt(leftX));
+    d.drawLine(rightX, 0, rightX, hAt(rightX));
+
+    // EPS core segments
+    const segments = getEpsSegments(leftX, rightX);
+    d.setActiveLayer('EPS');
+
+    segments.forEach(([segL, segR]) => {
+      const w = segR - segL;
+      if (w <= 0) return;
+
+      if (isMultiCourse && courses.length > 1) {
+        courses.forEach((course, ci) => {
+          const isBottomCourse = ci === 0;
+          const isTopCourse = ci === courses.length - 1;
+          const plateBelow = isBottomCourse ? BOTTOM_PLATE : (HALF_SPLINE - EPS_INSET);
+          const plateAbove = isTopCourse ? TOP_PLATE * 2 : (HALF_SPLINE - EPS_INSET);
+          const cEpsBot = course.y + plateBelow + EPS_INSET; // DXF Y from floor
+
+          if (isRaked) {
+            const courseTopDxf = isTopCourse
+              ? Infinity
+              : course.y + course.height - plateAbove - EPS_INSET;
+            const epsTopAtX = (x) => {
+              const wallTop = hAt(x) - TOP_PLATE * 2 - EPS_INSET;
+              return isTopCourse ? wallTop : Math.min(courseTopDxf, wallTop);
+            };
+            const epsTopL = epsTopAtX(segL);
+            const epsTopR = epsTopAtX(segR);
+            if (epsTopL <= cEpsBot && epsTopR <= cEpsBot) return;
+
+            const pts = [];
+            pts.push([segL, cEpsBot]);
+            pts.push([segR, cEpsBot]);
+            if (epsTopR > cEpsBot) pts.push([segR, epsTopR]);
+            if (isTopCourse && panel.peakHeight && panel.peakXLocal != null) {
+              const peakGX = panel.x + panel.peakXLocal;
+              if (peakGX > segL && peakGX < segR) pts.push([peakGX, epsTopAtX(peakGX)]);
+            }
+            if (epsTopL > cEpsBot) pts.push([segL, epsTopL]);
+            if (pts.length >= 3) d.drawPolyline(pts, true);
+          } else {
+            const cEpsTop = isTopCourse
+              ? hAt(leftX) - TOP_PLATE * 2 - EPS_INSET
+              : Math.min(course.y + course.height - plateAbove - EPS_INSET, hAt(leftX) - TOP_PLATE * 2 - EPS_INSET);
+            const cH = cEpsTop - cEpsBot;
+            if (cH > 0) {
+              d.drawPolyline([[segL, cEpsBot], [segR, cEpsBot], [segR, cEpsTop], [segL, cEpsTop]], true);
+            }
+          }
+        });
+      } else if (isRaked) {
+        const epsBot = BOTTOM_PLATE + EPS_INSET;
+        const epsTopL = hAt(segL) - TOP_PLATE * 2 - EPS_INSET;
+        const epsTopR = hAt(segR) - TOP_PLATE * 2 - EPS_INSET;
+        if (epsTopL <= epsBot && epsTopR <= epsBot) return;
+        const pts = [[segL, epsBot], [segR, epsBot]];
+        if (epsTopR > epsBot) pts.push([segR, epsTopR]);
+        if (panel.peakHeight && panel.peakXLocal != null) {
+          const peakGX = panel.x + panel.peakXLocal;
+          if (peakGX > segL && peakGX < segR) {
+            pts.push([peakGX, hAt(peakGX) - TOP_PLATE * 2 - EPS_INSET]);
+          }
+        }
+        if (epsTopL > epsBot) pts.push([segL, epsTopL]);
+        if (pts.length >= 3) d.drawPolyline(pts, true);
+      } else {
+        const epsBot = BOTTOM_PLATE + EPS_INSET;
+        const epsTop = height - TOP_PLATE * 2 - EPS_INSET;
+        if (epsTop > epsBot) {
+          d.drawPolyline([[segL, epsBot], [segR, epsBot], [segR, epsTop], [segL, epsTop]], true);
+        }
+      }
+    });
+  });
+
+  // ── Panel labels ──
+  d.setActiveLayer('LABELS');
+  basePanels.forEach((panel, i) => {
+    const cx = panel.x + panel.width / 2;
+    const midY = hAt(cx) / 2;
+    d.drawText(cx - 30, midY, 40, 0, `P${i + 1}`);
+  });
+
+  // ── Openings ──
+  drawOpenings(d, openings);
+  drawOpeningLabels(d, openings);
+
+  // ── Footer panels with EPS ──
+  footers.forEach((f) => {
+    d.setActiveLayer('OUTLINE');
+    d.drawPolyline([[f.x, 0], [f.x + f.width, 0], [f.x + f.width, f.height], [f.x, f.height]], true);
+
+    const op = openings.find(o => o.ref === f.ref);
+    if (op) {
+      const fEpsBot = BOTTOM_PLATE + EPS_INSET;
+      const fEpsTop = op.y - BOTTOM_PLATE - EPS_INSET;
+      if (fEpsTop > fEpsBot) {
+        const leftSplineRight = op.x - BOTTOM_PLATE;
+        const fEpsLeft = f.x < leftSplineRight ? leftSplineRight + EPS_INSET : f.x + EPS_INSET;
+        const rightSplineLeft = op.x + op.drawWidth + BOTTOM_PLATE;
+        const fEpsRight = f.x + f.width > rightSplineLeft ? rightSplineLeft - EPS_INSET : f.x + f.width - EPS_INSET;
+        if (fEpsRight > fEpsLeft) {
+          d.setActiveLayer('EPS');
+          d.drawPolyline([
+            [fEpsLeft, fEpsBot], [fEpsRight, fEpsBot],
+            [fEpsRight, fEpsTop], [fEpsLeft, fEpsTop],
+          ], true);
+        }
+      }
+    }
+
+    d.setActiveLayer('LABELS');
+    d.drawText(f.x + f.width / 2 - 40, f.height / 2, 30, 0, `Footer ${f.ref}`);
+  });
+
+  // ── Lintels ──
+  lintels.forEach((l) => {
+    const hL = l.heightLeft != null ? l.heightLeft : l.height;
+    const hR = l.heightRight != null ? l.heightRight : l.height;
+    const yBase = l.y;
+    const yTopL = l.y + hL;
+    const yTopR = l.y + hR;
+
+    d.setActiveLayer('OUTLINE');
+    const pts = l.peakHeight
+      ? [[l.x, yBase], [l.x, yTopL], [l.x + l.peakXLocal, l.y + l.peakHeight], [l.x + l.width, yTopR], [l.x + l.width, yBase]]
+      : [[l.x, yBase], [l.x, yTopL], [l.x + l.width, yTopR], [l.x + l.width, yBase]];
+    d.drawPolyline(pts, true);
+
+    // Timber beam
+    const op = openings.find(o => o.ref === l.ref);
+    if (op) {
+      const hasSill = op.y > 0;
+      const beamH = l.beamHeight || 200;
+      const beamLeft = hasSill ? op.x - BOTTOM_PLATE - SPLINE_WIDTH + EPS_INSET : op.x - BOTTOM_PLATE + EPS_INSET;
+      const beamRight = hasSill ? op.x + op.drawWidth + BOTTOM_PLATE + SPLINE_WIDTH - EPS_INSET : op.x + op.drawWidth + BOTTOM_PLATE - EPS_INSET;
+      const beamBot = l.y;
+      const beamTop = l.y + beamH;
+      d.drawPolyline([
+        [beamLeft, beamBot], [beamRight, beamBot],
+        [beamRight, beamTop], [beamLeft, beamTop],
+      ], true);
+
+      // EPS above beam
+      const epsBot = beamTop + EPS_INSET;
+      const epsLeft = beamLeft;
+      const epsRight = beamRight;
+      const epsTopAtX = (x) => hAt(x) - TOP_PLATE * 2 - EPS_INSET;
+      const epsTopL = epsTopAtX(epsLeft);
+      const epsTopR = epsTopAtX(epsRight);
+
+      if (epsTopL > epsBot || epsTopR > epsBot) {
+        d.setActiveLayer('EPS');
+        if (isRaked && Math.abs(epsTopL - epsTopR) > 0.5) {
+          const epsPts = [[epsLeft, epsBot], [epsRight, epsBot]];
+          if (epsTopR > epsBot) epsPts.push([epsRight, epsTopR]);
+          if (l.peakHeight && l.peakXLocal != null) {
+            const peakGX = l.x + l.peakXLocal;
+            if (peakGX > epsLeft && peakGX < epsRight) epsPts.push([peakGX, epsTopAtX(peakGX)]);
+          }
+          if (epsTopL > epsBot) epsPts.push([epsLeft, epsTopL]);
+          if (epsPts.length >= 3) d.drawPolyline(epsPts, true);
+        } else {
+          const epsTop = Math.max(epsTopL, epsTopR);
+          if (epsTop > epsBot) {
+            d.drawPolyline([
+              [epsLeft, epsBot], [epsRight, epsBot],
+              [epsRight, epsTop], [epsLeft, epsTop],
+            ], true);
+          }
+        }
+      }
+    }
+
+    d.setActiveLayer('LABELS');
+    const midH = Math.max(hL, hR, l.peakHeight || 0) / 2;
+    d.drawText(l.x + l.width / 2 - 40, l.y + midH / 2, 30, 0, `Lintel ${l.ref}`);
+  });
+
+  // ── Spline EPS (120mm inside 146mm splines) ──
+  const splineEpsX = MAGBOARD;
+  const splineEpsW = SPLINE_WIDTH - MAGBOARD * 2;
+  d.setActiveLayer('EPS_SPLINE');
+
+  // Joint splines
+  for (let i = 0; i < basePanels.length - 1; i++) {
+    const panel = basePanels[i];
+    const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
+    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
+    if (insideLintel || insideFooter) continue;
+
+    const epsXL = gapCentre - HALF_SPLINE + splineEpsX;
+    const epsXR = epsXL + splineEpsW;
+    const spBot = BOTTOM_PLATE + EPS_INSET;
+    const spTopL = hAt(epsXL) - TOP_PLATE * 2 - EPS_INSET;
+    const spTopR = hAt(epsXR) - TOP_PLATE * 2 - EPS_INSET;
+
+    if (spTopL <= spBot && spTopR <= spBot) continue;
+
+    if (!isRaked || Math.abs(spTopL - spTopR) < 0.5) {
+      const spTop = Math.max(spTopL, spTopR);
+      if (spTop > spBot) {
+        d.drawPolyline([[epsXL, spBot], [epsXR, spBot], [epsXR, spTop], [epsXL, spTop]], true);
+      }
+    } else {
+      const pts = [[epsXL, spBot], [epsXR, spBot]];
+      if (spTopR > spBot) pts.push([epsXR, spTopR]);
+      if (spTopL > spBot) pts.push([epsXL, spTopL]);
+      if (pts.length >= 3) d.drawPolyline(pts, true);
+    }
+  }
+
+  // Opening splines
+  for (const op of openings) {
+    if (op.y <= 0) continue;
+    const positions = [
+      op.x - BOTTOM_PLATE - SPLINE_WIDTH,
+      op.x + op.drawWidth + BOTTOM_PLATE,
+    ];
+    for (const spXPos of positions) {
+      const epsXL = spXPos + splineEpsX;
+      const epsXR = epsXL + splineEpsW;
+      const spBot = BOTTOM_PLATE + EPS_INSET;
+      const spTopL = hAt(epsXL) - TOP_PLATE * 2 - EPS_INSET;
+      const spTopR = hAt(epsXR) - TOP_PLATE * 2 - EPS_INSET;
+      if (spTopL <= spBot && spTopR <= spBot) continue;
+
+      if (!isRaked || Math.abs(spTopL - spTopR) < 0.5) {
+        const spTop = Math.max(spTopL, spTopR);
+        if (spTop > spBot) {
+          d.drawPolyline([[epsXL, spBot], [epsXR, spBot], [epsXR, spTop], [epsXL, spTop]], true);
+        }
+      } else {
+        const pts = [[epsXL, spBot], [epsXR, spBot]];
+        if (spTopR > spBot) pts.push([epsXR, spTopR]);
+        if (spTopL > spBot) pts.push([epsXL, spTopL]);
+        if (pts.length >= 3) d.drawPolyline(pts, true);
+      }
+    }
+  }
+
+  // Dimensions
+  drawDimensions(d, layout);
+  drawRunningMeasurement(d, layout);
+
+  return d;
+}
+
+/**
+ * Export EPS elevation plan as a DXF file download.
+ */
+export function exportEpsElevationDxf(layout, wallName, projectName) {
+  const d = buildEpsElevationDxf(layout, wallName);
+  const parts = [projectName, wallName, 'EPS Elevation'].filter(Boolean);
+  const filename = parts.join(' ').replace(/\s+/g, ' ').trim() + '.dxf';
+  downloadDxf(d, filename);
+}

--- a/devpro-wall-builder/src/utils/epsPlanDxf.js
+++ b/devpro-wall-builder/src/utils/epsPlanDxf.js
@@ -1,0 +1,254 @@
+/**
+ * DXF export for EPS Cut Plans.
+ *
+ * Generates individual EPS block cutting diagrams, laid out in a grid.
+ * Each piece is drawn as a dimensioned rectangle at 1:1 mm scale.
+ */
+import { BOTTOM_PLATE, TOP_PLATE, PANEL_GAP, SPLINE_WIDTH } from './constants.js';
+import { createDrawing, downloadDxf } from './dxfExporter.js';
+
+const HALF_SPLINE = SPLINE_WIDTH / 2;
+const EPS_INSET = 10;
+
+/**
+ * Build cut piece lists from layout (mirrors EpsCutPlans.jsx logic).
+ */
+function buildCutPieces(layout) {
+  const { height, panels, openings, footers, lintels, deductionLeft, deductionRight, grossLength, courses, isMultiCourse, isRaked } = layout;
+
+  const epsTop = TOP_PLATE * 2 + EPS_INSET;
+  const epsBottom = height - BOTTOM_PLATE - EPS_INSET;
+  const epsHeight = epsBottom - epsTop;
+
+  // Build exclusion zones
+  const exclusions = [];
+  if (deductionLeft > 0) exclusions.push([deductionLeft, deductionLeft + BOTTOM_PLATE]);
+  if (deductionRight > 0) exclusions.push([grossLength - deductionRight - BOTTOM_PLATE, grossLength - deductionRight]);
+
+  for (let i = 0; i < panels.length - 1; i++) {
+    const panel = panels[i];
+    const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
+    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
+    if (!insideLintel && !insideFooter) exclusions.push([gapCentre - HALF_SPLINE, gapCentre + HALF_SPLINE]);
+  }
+
+  for (const op of openings) {
+    const hasSill = op.y > 0;
+    exclusions.push([op.x - BOTTOM_PLATE, op.x]);
+    if (hasSill) exclusions.push([op.x - BOTTOM_PLATE - SPLINE_WIDTH, op.x - BOTTOM_PLATE]);
+    exclusions.push([op.x + op.drawWidth, op.x + op.drawWidth + BOTTOM_PLATE]);
+    if (hasSill) exclusions.push([op.x + op.drawWidth + BOTTOM_PLATE, op.x + op.drawWidth + BOTTOM_PLATE + SPLINE_WIDTH]);
+    exclusions.push([op.x, op.x + op.drawWidth]);
+  }
+
+  for (const p of panels) {
+    if (p.type === 'end') exclusions.push([p.x + p.width - BOTTOM_PLATE, p.x + p.width]);
+    if (deductionRight === 0 && Math.abs(p.x + p.width - grossLength) < 1) exclusions.push([grossLength - BOTTOM_PLATE, grossLength]);
+    if (deductionLeft === 0 && Math.abs(p.x) < 1) exclusions.push([0, BOTTOM_PLATE]);
+  }
+
+  for (const l of lintels) exclusions.push([l.x, l.x + l.width]);
+  exclusions.sort((a, b) => a[0] - b[0]);
+
+  const getEpsSegments = (panelLeft, panelRight) => {
+    const clipped = [];
+    for (const [eL, eR] of exclusions) {
+      const cL = Math.max(eL, panelLeft);
+      const cR = Math.min(eR, panelRight);
+      if (cL < cR) clipped.push([cL, cR]);
+    }
+    const merged = [];
+    for (const zone of clipped) {
+      if (merged.length > 0 && zone[0] <= merged[merged.length - 1][1]) {
+        merged[merged.length - 1][1] = Math.max(merged[merged.length - 1][1], zone[1]);
+      } else {
+        merged.push([...zone]);
+      }
+    }
+    const segs = [];
+    let cursor = panelLeft + EPS_INSET;
+    for (const [eL, eR] of merged) {
+      const segRight = eL - EPS_INSET;
+      if (cursor < segRight) segs.push([cursor, segRight]);
+      cursor = eR + EPS_INSET;
+    }
+    const segRight = panelRight - EPS_INSET;
+    if (cursor < segRight) segs.push([cursor, segRight]);
+    return segs;
+  };
+
+  // Panel EPS pieces
+  const pieces = [];
+  panels.forEach((panel) => {
+    const segments = getEpsSegments(panel.x, panel.x + panel.width);
+    const panelEpsH = isRaked
+      ? Math.round(((panel.heightLeft + panel.heightRight) / 2) - BOTTOM_PLATE - TOP_PLATE * 2 - EPS_INSET * 2)
+      : epsHeight;
+
+    if (isMultiCourse && courses.length > 1) {
+      segments.forEach((seg, j) => {
+        const w = Math.round(seg[1] - seg[0]);
+        if (w <= 0) return;
+        courses.forEach((course, ci) => {
+          const plateAbove = ci === 0 ? TOP_PLATE * 2 : TOP_PLATE;
+          const plateBelow = ci === courses.length - 1 ? BOTTOM_PLATE : TOP_PLATE;
+          const courseEpsH = course.height - plateAbove - plateBelow - EPS_INSET * 2;
+          if (courseEpsH <= 0) return;
+          const suffix = segments.length > 1 ? ` (${String.fromCharCode(97 + j)})` : '';
+          pieces.push({ label: `P${panel.index + 1}${suffix} C${ci + 1}`, width: w, height: Math.round(courseEpsH) });
+        });
+      });
+    } else {
+      segments.forEach((seg, j) => {
+        const w = Math.round(seg[1] - seg[0]);
+        if (w > 0 && panelEpsH > 0) {
+          const label = segments.length > 1 ? `P${panel.index + 1} (${String.fromCharCode(97 + j)})` : `P${panel.index + 1}`;
+          pieces.push({ label, width: w, height: panelEpsH });
+        }
+      });
+    }
+  });
+
+  // Footer EPS pieces
+  footers.forEach((f) => {
+    const op = openings.find(o => o.ref === f.ref);
+    if (!op) return;
+    const fEpsTop = height - op.y + BOTTOM_PLATE + EPS_INSET;
+    const fEpsBot = height - BOTTOM_PLATE - EPS_INSET;
+    if (fEpsBot <= fEpsTop) return;
+    const leftSplineRight = op.x - BOTTOM_PLATE;
+    const fEpsLeft = f.x < leftSplineRight ? leftSplineRight + EPS_INSET : f.x + EPS_INSET;
+    const rightSplineLeft = op.x + op.drawWidth + BOTTOM_PLATE;
+    const fEpsRight = f.x + f.width > rightSplineLeft ? rightSplineLeft - EPS_INSET : f.x + f.width - EPS_INSET;
+    if (fEpsRight <= fEpsLeft) return;
+    pieces.push({ label: `Footer ${f.ref}`, width: Math.round(fEpsRight - fEpsLeft), height: Math.round(fEpsBot - fEpsTop) });
+  });
+
+  // Spline EPS pieces
+  const splineH = height - BOTTOM_PLATE - TOP_PLATE * 2 - 10;
+  const splinePieces = [];
+  for (let i = 0; i < panels.length - 1; i++) {
+    const panel = panels[i];
+    const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
+    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
+    if (!insideLintel && !insideFooter) {
+      splinePieces.push({ label: `Joint P${panels[i].index + 1}/P${panels[i + 1].index + 1}`, width: SPLINE_WIDTH, height: splineH });
+    }
+  }
+  for (const op of openings) {
+    if (op.y > 0) {
+      splinePieces.push({ label: `${op.ref} Left`, width: SPLINE_WIDTH, height: splineH });
+      splinePieces.push({ label: `${op.ref} Right`, width: SPLINE_WIDTH, height: splineH });
+    }
+  }
+
+  return { pieces, splinePieces };
+}
+
+/**
+ * Draw a single dimensioned cut piece at position (ox, oy).
+ */
+function drawCutPiece(d, ox, oy, piece) {
+  const { width: w, height: h, label } = piece;
+  const dimOffset = 80;
+
+  // Rectangle
+  d.setActiveLayer('EPS');
+  d.drawPolyline([[ox, oy], [ox + w, oy], [ox + w, oy + h], [ox, oy + h]], true);
+
+  // Label
+  d.setActiveLayer('LABELS');
+  const textSize = Math.min(40, w / 4, h / 4);
+  d.drawText(ox + w / 2 - textSize * label.length / 4, oy + h / 2 + textSize / 3, textSize, 0, label);
+  d.drawText(ox + w / 2 - textSize * 3, oy + h / 2 - textSize, textSize * 0.7, 0, `${w} x ${h} mm`);
+
+  // Width dimension (top)
+  d.setActiveLayer('DIMENSIONS');
+  d.drawLine(ox, oy + h + dimOffset / 2, ox + w, oy + h + dimOffset / 2);
+  d.drawLine(ox, oy + h + dimOffset / 2 - 15, ox, oy + h + dimOffset / 2 + 15);
+  d.drawLine(ox + w, oy + h + dimOffset / 2 - 15, ox + w, oy + h + dimOffset / 2 + 15);
+  d.drawText(ox + w / 2 - 40, oy + h + dimOffset / 2 + 20, 30, 0, `${w}`);
+
+  // Height dimension (right)
+  d.drawLine(ox + w + dimOffset / 2, oy, ox + w + dimOffset / 2, oy + h);
+  d.drawLine(ox + w + dimOffset / 2 - 15, oy, ox + w + dimOffset / 2 + 15, oy);
+  d.drawLine(ox + w + dimOffset / 2 - 15, oy + h, ox + w + dimOffset / 2 + 15, oy + h);
+  d.drawText(ox + w + dimOffset / 2 + 20, oy + h / 2, 30, 90, `${h}`);
+}
+
+/**
+ * Build the DXF drawing for EPS cut plans.
+ */
+export function buildEpsPlanDxf(layout, wallName) {
+  const d = createDrawing();
+  const { pieces, splinePieces } = buildCutPieces(layout);
+
+  if (pieces.length === 0 && splinePieces.length === 0) return d;
+
+  const spacing = 200; // gap between pieces
+  const maxRowWidth = 8000; // max width before wrapping to next row
+
+  // Title
+  d.setActiveLayer('LABELS');
+  d.drawText(0, -200, 60, 0, `${wallName || 'Wall'} — EPS Cut Plans`);
+
+  // Layout panel EPS pieces in a grid
+  let cursorX = 0;
+  let cursorY = 0;
+  let rowMaxH = 0;
+
+  if (pieces.length > 0) {
+    d.setActiveLayer('LABELS');
+    d.drawText(0, cursorY - 100, 45, 0, 'Panel EPS — 142mm thick');
+    cursorY -= 200;
+    cursorX = 0;
+    rowMaxH = 0;
+
+    for (const piece of pieces) {
+      if (cursorX > 0 && cursorX + piece.width > maxRowWidth) {
+        cursorX = 0;
+        cursorY -= rowMaxH + spacing + 200;
+        rowMaxH = 0;
+      }
+      drawCutPiece(d, cursorX, cursorY - piece.height, piece);
+      rowMaxH = Math.max(rowMaxH, piece.height);
+      cursorX += piece.width + spacing;
+    }
+  }
+
+  // Spline EPS pieces
+  if (splinePieces.length > 0) {
+    cursorY -= rowMaxH + spacing + 400;
+    cursorX = 0;
+    rowMaxH = 0;
+
+    d.setActiveLayer('LABELS');
+    d.drawText(0, cursorY, 45, 0, 'Spline EPS — 120mm thick');
+    cursorY -= 200;
+
+    for (const piece of splinePieces) {
+      if (cursorX > 0 && cursorX + piece.width > maxRowWidth) {
+        cursorX = 0;
+        cursorY -= rowMaxH + spacing + 200;
+        rowMaxH = 0;
+      }
+      drawCutPiece(d, cursorX, cursorY - piece.height, piece);
+      rowMaxH = Math.max(rowMaxH, piece.height);
+      cursorX += piece.width + spacing;
+    }
+  }
+
+  return d;
+}
+
+/**
+ * Export EPS cut plans as a DXF file download.
+ */
+export function exportEpsPlanDxf(layout, wallName, projectName) {
+  const d = buildEpsPlanDxf(layout, wallName);
+  const parts = [projectName, wallName, 'EPS Cut Plans'].filter(Boolean);
+  const filename = parts.join(' ').replace(/\s+/g, ' ').trim() + '.dxf';
+  downloadDxf(d, filename);
+}

--- a/devpro-wall-builder/src/utils/externalElevationDxf.js
+++ b/devpro-wall-builder/src/utils/externalElevationDxf.js
@@ -1,0 +1,200 @@
+/**
+ * DXF export for External Elevation View.
+ *
+ * Ports the geometry logic from WallDrawing.jsx into DXF entities.
+ * All coordinates in mm, Y=0 at floor line, positive up.
+ */
+import { BOTTOM_PLATE, TOP_PLATE, PANEL_GAP } from './constants.js';
+import {
+  createDrawing, drawWallOutline, drawDimensions,
+  drawRunningMeasurement, drawTitle, downloadDxf,
+} from './dxfExporter.js';
+
+/**
+ * Build the DXF drawing for an external elevation view.
+ */
+export function buildExternalElevationDxf(layout, wallName) {
+  const d = createDrawing();
+  const {
+    grossLength, height, maxHeight, panels, openings, footers, lintels,
+    deductionLeft, deductionRight, isRaked, heightAt, profile,
+    courses, isMultiCourse,
+  } = layout;
+
+  const useHeight = maxHeight || height;
+  const hAt = (x) => heightAt ? heightAt(x) : height;
+
+  // Title
+  drawTitle(d, `${wallName || 'Wall'} — External Elevation View${isRaked ? ` (${profile})` : ''}`,
+    `${grossLength}mm x ${isRaked ? `${layout.heightLeft}-${layout.heightRight}mm` : `${height}mm`} | ${layout.totalPanels} panels`,
+    grossLength);
+
+  // Wall outline
+  drawWallOutline(d, layout);
+
+  // ── Corner deductions ──
+  if (deductionLeft > 0) {
+    d.setActiveLayer('OUTLINE');
+    const topY = hAt(0);
+    d.drawPolyline([[0, 0], [deductionLeft, 0], [deductionLeft, hAt(deductionLeft)], [0, topY]], true);
+    d.setActiveLayer('LABELS');
+    d.drawText(deductionLeft / 2 - 20, -40, 30, 0, `-${deductionLeft}`);
+  }
+  if (deductionRight > 0) {
+    d.setActiveLayer('OUTLINE');
+    const x = grossLength - deductionRight;
+    d.drawPolyline([[x, 0], [grossLength, 0], [grossLength, hAt(grossLength)], [x, hAt(x)]], true);
+    d.setActiveLayer('LABELS');
+    d.drawText(grossLength - deductionRight / 2 - 20, -40, 30, 0, `-${deductionRight}`);
+  }
+
+  // ── Panels ──
+  const basePanels = panels.filter(p => (p.course ?? 0) === 0);
+  const posMap = new Map(basePanels.map((p, idx) => [p.x, idx]));
+
+  panels.forEach((panel) => {
+    const pLeft = panel.x;
+    const pRight = panel.x + panel.width;
+    const courseIdx = panel.course ?? 0;
+    const course = courses?.[courseIdx];
+    const cY = course?.y ?? 0;
+    const cTop = cY + (course?.height ?? height);
+
+    const pBot = cY;
+    const pTopL = Math.max(Math.min(hAt(pLeft), cTop), cY);
+    const pTopR = Math.max(Math.min(hAt(pRight), cTop), cY);
+
+    // Panel outline
+    d.setActiveLayer('OUTLINE');
+    const pts = [[pLeft, pBot], [pLeft, pTopL]];
+    if (panel.peakHeight && panel.peakXLocal != null) {
+      const peakX = panel.x + panel.peakXLocal;
+      const peakH = Math.max(Math.min(hAt(peakX), cTop), cY);
+      pts.push([peakX, peakH]);
+    }
+    pts.push([pRight, pTopR], [pRight, pBot]);
+    d.drawPolyline(pts, true);
+
+    // Panel label
+    d.setActiveLayer('LABELS');
+    const posIdx = posMap.get(panel.x) ?? 0;
+    const label = isMultiCourse ? `P${posIdx + 1}.C${courseIdx + 1}` : `P${posIdx + 1}`;
+    const midY = (pBot + Math.min(pTopL, pTopR)) / 2;
+    d.drawText(pLeft + panel.width / 2 - 30, midY, 35, 0, label);
+
+    // Width label (course 0 only)
+    if (courseIdx === 0) {
+      d.drawText(pLeft + panel.width / 2 - 30, -40, 30, 0, `${panel.width}`);
+    }
+  });
+
+  // Panel divider lines (course 0 only)
+  d.setActiveLayer('OUTLINE');
+  basePanels.forEach((panel, i) => {
+    if (i < basePanels.length - 1) {
+      const xR = panel.x + panel.width;
+      d.drawLine(xR, 0, xR, hAt(xR));
+    }
+  });
+
+  // ── Openings ──
+  d.setActiveLayer('OPENINGS');
+  for (const op of openings) {
+    const x1 = op.x;
+    const y1 = op.y;
+    const x2 = op.x + op.drawWidth;
+    const y2 = op.y + op.drawHeight;
+    d.drawPolyline([[x1, y1], [x2, y1], [x2, y2], [x1, y2]], true);
+    d.drawLine(x1, y1, x2, y2);
+    d.drawLine(x2, y1, x1, y2);
+
+    d.setActiveLayer('LABELS');
+    d.drawText(op.x + op.drawWidth / 2 - 30, op.y + op.drawHeight / 2 + 20, 40, 0, op.ref);
+    d.drawText(op.x + op.drawWidth / 2 - 60, op.y + op.drawHeight / 2 - 30, 28, 0, `${op.width_mm}w x ${op.height_mm}h`);
+    d.setActiveLayer('OPENINGS');
+  }
+
+  // ── Footers ──
+  for (const f of footers) {
+    d.setActiveLayer('FRAMING');
+    d.drawPolyline([[f.x, 0], [f.x + f.width, 0], [f.x + f.width, f.height], [f.x, f.height]], true);
+    d.setActiveLayer('LABELS');
+    d.drawText(f.x + f.width / 2 - 40, f.height / 2, 28, 0, `Footer ${f.ref}`);
+    d.drawText(f.x + f.width / 2 - 20, -40, 30, 0, `${f.width}`);
+  }
+
+  // ── Lintels ──
+  for (const l of lintels) {
+    const hL = l.heightLeft != null ? l.heightLeft : l.height;
+    const hR = l.heightRight != null ? l.heightRight : l.height;
+    const yBase = l.y;
+    const yTopL = l.y + hL;
+    const yTopR = l.y + hR;
+
+    d.setActiveLayer('FRAMING');
+    const pts = l.peakHeight
+      ? [[l.x, yBase], [l.x, yTopL], [l.x + l.peakXLocal, l.y + l.peakHeight], [l.x + l.width, yTopR], [l.x + l.width, yBase]]
+      : [[l.x, yBase], [l.x, yTopL], [l.x + l.width, yTopR], [l.x + l.width, yBase]];
+    d.drawPolyline(pts, true);
+
+    d.setActiveLayer('LABELS');
+    const midH = Math.max(hL, hR, l.peakHeight || 0) / 2;
+    d.drawText(l.x + l.width / 2 - 40, l.y + midH / 2, 28, 0, `Lintel ${l.ref}`);
+  }
+
+  // ── Course join lines ──
+  if (isMultiCourse && courses.length > 1) {
+    d.setActiveLayer('DIMENSIONS');
+    courses.slice(1).forEach((course) => {
+      // Find x-range where wall height >= course.y
+      const hAtX = heightAt || (() => height);
+      const breakpoints = [0, grossLength];
+      if (layout.peakPosition != null && layout.peakPosition > 0 && layout.peakPosition < grossLength) {
+        breakpoints.push(layout.peakPosition);
+      }
+      breakpoints.sort((a, b) => a - b);
+
+      let x0 = null, x1 = null;
+      for (let k = 0; k < breakpoints.length - 1; k++) {
+        const bL = breakpoints[k], bR = breakpoints[k + 1];
+        const hL = hAtX(bL), hR = hAtX(bR);
+        if (hL < course.y && hR < course.y) continue;
+        let segL = bL, segR = bR;
+        if (hL < course.y) segL = bL + (course.y - hL) / (hR - hL) * (bR - bL);
+        if (hR < course.y) segR = bL + (course.y - hL) / (hR - hL) * (bR - bL);
+        if (x0 === null || segL < x0) x0 = segL;
+        if (x1 === null || segR > x1) x1 = segR;
+      }
+      if (x0 !== null) {
+        d.drawLine(x0, course.y, x1, course.y);
+        d.setActiveLayer('LABELS');
+        d.drawText(x1 + 30, course.y, 30, 0, `${course.y}`);
+        d.setActiveLayer('DIMENSIONS');
+      }
+    });
+  }
+
+  // ── Peak height label (gable) ──
+  if (profile === 'gable' && layout.peakPosition != null) {
+    d.setActiveLayer('DIMENSIONS');
+    const px = layout.peakPosition;
+    const ph = layout.peakHeight;
+    d.drawText(px - 60, hAt(px) + 60, 35, 0, `Peak ${ph}mm`);
+  }
+
+  // Dimensions
+  drawDimensions(d, layout);
+  drawRunningMeasurement(d, layout);
+
+  return d;
+}
+
+/**
+ * Export external elevation view as a DXF file download.
+ */
+export function exportExternalElevationDxf(layout, wallName, projectName) {
+  const d = buildExternalElevationDxf(layout, wallName);
+  const parts = [projectName, wallName, 'External Elevation'].filter(Boolean);
+  const filename = parts.join(' ').replace(/\s+/g, ' ').trim() + '.dxf';
+  downloadDxf(d, filename);
+}

--- a/devpro-wall-builder/src/utils/framingElevationDxf.js
+++ b/devpro-wall-builder/src/utils/framingElevationDxf.js
@@ -1,0 +1,419 @@
+/**
+ * DXF export for Framing Elevation Plan.
+ *
+ * Ports the geometry logic from FramingElevation.jsx into DXF entities.
+ * All coordinates in mm, Y=0 at floor line, positive up.
+ */
+import { BOTTOM_PLATE, TOP_PLATE, PANEL_GAP, SPLINE_WIDTH, HSPLINE_CLEARANCE, WINDOW_OVERHANG, buildHSplineSegments } from './constants.js';
+import {
+  createDrawing, drawWallOutline, drawDimensions,
+  drawRunningMeasurement, drawTitle, downloadDxf,
+} from './dxfExporter.js';
+
+const HALF_SPLINE = SPLINE_WIDTH / 2;
+const EPS_INSET = 10;
+
+/**
+ * Build the DXF drawing for a framing elevation plan.
+ */
+export function buildFramingElevationDxf(layout, wallName) {
+  const d = createDrawing();
+  const {
+    grossLength, height, maxHeight, panels, openings, footers, lintels,
+    deductionLeft, deductionRight, isRaked, heightAt, courses, isMultiCourse,
+  } = layout;
+
+  const useHeight = maxHeight || height;
+  const hAt = (x) => heightAt ? heightAt(x) : height;
+  const plateLeft = deductionLeft;
+  const plateRight = grossLength - deductionRight;
+
+  // Title
+  drawTitle(d, `${wallName || 'Wall'} — Framing Elevation`,
+    `${grossLength}mm x ${height}mm${isRaked ? ` (max ${useHeight}mm)` : ''} | Bottom plate ${BOTTOM_PLATE}mm, 2x top plate ${TOP_PLATE}mm`,
+    grossLength);
+
+  // Wall outline
+  drawWallOutline(d, layout);
+
+  // ── Bottom plate line ──
+  d.setActiveLayer('FRAMING');
+  d.drawLine(plateLeft, BOTTOM_PLATE, plateRight, BOTTOM_PLATE);
+
+  // ── Top plate lines (follow slope) ──
+  if (!isRaked) {
+    d.drawLine(plateLeft, hAt(plateLeft) - TOP_PLATE, plateRight, hAt(plateRight) - TOP_PLATE);
+    d.drawLine(plateLeft, hAt(plateLeft) - TOP_PLATE * 2, plateRight, hAt(plateRight) - TOP_PLATE * 2);
+  } else {
+    const steps = Math.max(20, Math.round(grossLength / 100));
+    const buildPlatePts = (offset) => {
+      const pts = [];
+      for (let i = 0; i <= steps; i++) {
+        const x = plateLeft + (i / steps) * (plateRight - plateLeft);
+        pts.push([x, hAt(x) - offset]);
+      }
+      return pts;
+    };
+    const tp1 = buildPlatePts(TOP_PLATE);
+    const tp2 = buildPlatePts(TOP_PLATE * 2);
+    for (let i = 0; i < tp1.length - 1; i++) {
+      d.drawLine(tp1[i][0], tp1[i][1], tp1[i + 1][0], tp1[i + 1][1]);
+    }
+    for (let i = 0; i < tp2.length - 1; i++) {
+      d.drawLine(tp2[i][0], tp2[i][1], tp2[i + 1][0], tp2[i + 1][1]);
+    }
+  }
+
+  // ── Corner deductions ──
+  if (deductionLeft > 0) {
+    d.setActiveLayer('OUTLINE');
+    const topY = hAt(0);
+    d.drawPolyline([[0, 0], [deductionLeft, 0], [deductionLeft, topY], [0, topY]], true);
+
+    d.setActiveLayer('LABELS');
+    d.drawText(deductionLeft / 2 - 20, -40, 30, 0, `-${deductionLeft}`);
+
+    // Vertical plate at deduction edge
+    d.setActiveLayer('FRAMING');
+    const pTop = hAt(deductionLeft) - TOP_PLATE * 2;
+    const pH = pTop - BOTTOM_PLATE;
+    if (pH > 0) {
+      d.drawPolyline([
+        [deductionLeft, BOTTOM_PLATE], [deductionLeft + BOTTOM_PLATE, BOTTOM_PLATE],
+        [deductionLeft + BOTTOM_PLATE, pTop], [deductionLeft, pTop],
+      ], true);
+    }
+  }
+
+  if (deductionRight > 0) {
+    d.setActiveLayer('OUTLINE');
+    const x = grossLength - deductionRight;
+    const topY = hAt(grossLength);
+    d.drawPolyline([[x, 0], [grossLength, 0], [grossLength, topY], [x, topY]], true);
+
+    d.setActiveLayer('LABELS');
+    d.drawText(grossLength - deductionRight / 2 - 20, -40, 30, 0, `-${deductionRight}`);
+
+    // Vertical plate at deduction edge
+    d.setActiveLayer('FRAMING');
+    const pTop = hAt(x) - TOP_PLATE * 2;
+    const pH = pTop - BOTTOM_PLATE;
+    if (pH > 0) {
+      d.drawPolyline([
+        [x - BOTTOM_PLATE, BOTTOM_PLATE], [x, BOTTOM_PLATE],
+        [x, pTop], [x - BOTTOM_PLATE, pTop],
+      ], true);
+    }
+  }
+
+  // ── Panel edges ──
+  const basePanels = panels.filter(p => (p.course ?? 0) === 0);
+
+  basePanels.forEach((panel) => {
+    const leftX = panel.x;
+    const rightX = panel.x + panel.width;
+
+    d.setActiveLayer('FRAMING');
+
+    // Vertical edge helper: compute segments excluding lintel/footer zones
+    const getExclusions = (xEdge) => {
+      const zones = [];
+      for (const l of lintels) {
+        if (l.x < xEdge && xEdge < l.x + l.width) {
+          const hL = l.heightLeft != null ? l.heightLeft : l.height;
+          const hR = l.heightRight != null ? l.heightRight : l.height;
+          const t = l.width > 0 ? (xEdge - l.x) / l.width : 0;
+          const hAtX = hL + (hR - hL) * t;
+          zones.push([l.y, l.y + hAtX]); // DXF Y
+        }
+      }
+      for (const f of footers) {
+        if (f.x < xEdge && xEdge < f.x + f.width) {
+          zones.push([0, f.height]);
+        }
+      }
+      zones.sort((a, b) => a[0] - b[0]);
+      return zones;
+    };
+
+    const vertSegments = (xEdge) => {
+      const excl = getExclusions(xEdge);
+      const topY = hAt(xEdge);
+      const segs = [];
+      let cursor = 0;
+      for (const [eBot, eTop] of excl) {
+        if (cursor < eBot) segs.push([cursor, eBot]);
+        cursor = Math.max(cursor, eTop);
+      }
+      if (cursor < topY) segs.push([cursor, topY]);
+      return segs;
+    };
+
+    // Top edge
+    if (panel.peakHeight) {
+      const peakX = panel.x + panel.peakXLocal;
+      d.drawLine(leftX, hAt(leftX), peakX, hAt(peakX));
+      d.drawLine(peakX, hAt(peakX), rightX, hAt(rightX));
+    } else {
+      d.drawLine(leftX, hAt(leftX), rightX, hAt(rightX));
+    }
+    // Bottom edge
+    d.drawLine(leftX, 0, rightX, 0);
+    // Left vertical segments
+    for (const [y1, y2] of vertSegments(leftX)) d.drawLine(leftX, y1, leftX, y2);
+    // Right vertical segments
+    for (const [y1, y2] of vertSegments(rightX)) d.drawLine(rightX, y1, rightX, y2);
+  });
+
+  // ── Panel labels ──
+  d.setActiveLayer('LABELS');
+  const posMap = new Map(basePanels.map((p, idx) => [p.x, idx]));
+  panels.forEach((panel) => {
+    const courseIdx = panel.course ?? 0;
+    const posIdx = posMap.get(panel.x) ?? 0;
+    const label = isMultiCourse ? `P${posIdx + 1}.C${courseIdx + 1}` : `P${posIdx + 1}`;
+    const cx = panel.x + panel.width / 2;
+    const midY = hAt(cx) / 2;
+    d.drawText(cx - 30, midY, 35, 0, label);
+  });
+
+  // Panel base width labels
+  basePanels.forEach((panel) => {
+    d.drawText(panel.x + panel.width / 2 - 30, -40, 30, 0, `${panel.width}`);
+  });
+
+  // ── Vertical plates at panel outer edges (45mm) ──
+  d.setActiveLayer('FRAMING');
+  const plates = [];
+  for (const panel of basePanels) {
+    if (panel.type === 'end') plates.push(panel.x + panel.width - BOTTOM_PLATE);
+    if (deductionRight === 0 && Math.abs(panel.x + panel.width - grossLength) < 1) plates.push(grossLength - BOTTOM_PLATE);
+    if (deductionLeft === 0 && Math.abs(panel.x) < 1) plates.push(0);
+  }
+  const uniquePlates = [...new Set(plates)];
+  for (const plateX of uniquePlates) {
+    const pTop = hAt(plateX) - TOP_PLATE * 2;
+    const pBot = BOTTOM_PLATE;
+    if (pTop > pBot) {
+      d.drawPolyline([
+        [plateX, pBot], [plateX + BOTTOM_PLATE, pBot],
+        [plateX + BOTTOM_PLATE, pTop], [plateX, pTop],
+      ], true);
+    }
+  }
+
+  // ── Panel joint splines (146mm centred on 5mm gap) ──
+  for (let i = 0; i < basePanels.length - 1; i++) {
+    const panel = basePanels[i];
+    const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
+    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
+    if (insideLintel || insideFooter) continue;
+
+    const spXL = gapCentre - HALF_SPLINE;
+    const spXR = gapCentre + HALF_SPLINE;
+    const spBot = BOTTOM_PLATE;
+    const spTopL = hAt(spXL) - TOP_PLATE * 2;
+    const spTopR = hAt(spXR) - TOP_PLATE * 2;
+
+    if (spTopL <= spBot && spTopR <= spBot) continue;
+
+    if (!isRaked || Math.abs(spTopL - spTopR) < 0.5) {
+      const spTop = Math.max(spTopL, spTopR);
+      if (spTop > spBot) {
+        d.drawPolyline([[spXL, spBot], [spXR, spBot], [spXR, spTop], [spXL, spTop]], true);
+      }
+    } else {
+      const pts = [[spXL, spBot], [spXR, spBot]];
+      if (spTopR > spBot) pts.push([spXR, spTopR]);
+      if (spTopL > spBot) pts.push([spXL, spTopL]);
+      if (pts.length >= 3) d.drawPolyline(pts, true);
+    }
+  }
+
+  // ── Openings ──
+  d.setActiveLayer('OPENINGS');
+  for (const op of openings) {
+    const x1 = op.x;
+    const y1 = op.y;
+    const x2 = op.x + op.drawWidth;
+    const y2 = op.y + op.drawHeight;
+    d.drawPolyline([[x1, y1], [x2, y1], [x2, y2], [x1, y2]], true);
+    d.drawLine(x1, y1, x2, y2);
+    d.drawLine(x2, y1, x1, y2);
+
+    d.setActiveLayer('LABELS');
+    d.drawText(op.x + op.drawWidth / 2 - 30, op.y + op.drawHeight / 2, 35, 0, op.ref);
+    d.drawText(op.x + op.drawWidth / 2 - 60, op.y + op.drawHeight / 2 - 50, 28, 0, `${op.width_mm}w x ${op.height_mm}h`);
+    d.setActiveLayer('OPENINGS');
+  }
+
+  // ── Plates around openings ──
+  d.setActiveLayer('FRAMING');
+  for (const op of openings) {
+    const hasSill = op.y > 0;
+    const opBot = op.y;
+    const opTop = op.y + op.drawHeight;
+
+    // Sill plate
+    if (hasSill) {
+      d.drawPolyline([
+        [op.x - BOTTOM_PLATE, opBot - BOTTOM_PLATE],
+        [op.x + op.drawWidth + BOTTOM_PLATE, opBot - BOTTOM_PLATE],
+        [op.x + op.drawWidth + BOTTOM_PLATE, opBot],
+        [op.x - BOTTOM_PLATE, opBot],
+      ], true);
+    }
+
+    // Left vertical plate
+    d.drawPolyline([
+      [op.x - BOTTOM_PLATE, opBot], [op.x, opBot],
+      [op.x, opTop], [op.x - BOTTOM_PLATE, opTop],
+    ], true);
+
+    // Right vertical plate
+    d.drawPolyline([
+      [op.x + op.drawWidth, opBot], [op.x + op.drawWidth + BOTTOM_PLATE, opBot],
+      [op.x + op.drawWidth + BOTTOM_PLATE, opTop], [op.x + op.drawWidth, opTop],
+    ], true);
+
+    // Opening splines (for windows with sills)
+    if (hasSill) {
+      const spBot = BOTTOM_PLATE;
+      // Left spline
+      const lSpXL = op.x - BOTTOM_PLATE - SPLINE_WIDTH;
+      const lSpXR = op.x - BOTTOM_PLATE;
+      const lSpTopL = hAt(lSpXL) - TOP_PLATE * 2;
+      const lSpTopR = hAt(lSpXR) - TOP_PLATE * 2;
+      if (!isRaked || Math.abs(lSpTopL - lSpTopR) < 0.5) {
+        const spTop = Math.max(lSpTopL, lSpTopR);
+        if (spTop > spBot) d.drawPolyline([[lSpXL, spBot], [lSpXR, spBot], [lSpXR, spTop], [lSpXL, spTop]], true);
+      } else {
+        const pts = [[lSpXL, spBot], [lSpXR, spBot]];
+        if (lSpTopR > spBot) pts.push([lSpXR, lSpTopR]);
+        if (lSpTopL > spBot) pts.push([lSpXL, lSpTopL]);
+        if (pts.length >= 3) d.drawPolyline(pts, true);
+      }
+
+      // Right spline
+      const rSpXL = op.x + op.drawWidth + BOTTOM_PLATE;
+      const rSpXR = rSpXL + SPLINE_WIDTH;
+      const rSpTopL = hAt(rSpXL) - TOP_PLATE * 2;
+      const rSpTopR = hAt(rSpXR) - TOP_PLATE * 2;
+      if (!isRaked || Math.abs(rSpTopL - rSpTopR) < 0.5) {
+        const spTop = Math.max(rSpTopL, rSpTopR);
+        if (spTop > spBot) d.drawPolyline([[rSpXL, spBot], [rSpXR, spBot], [rSpXR, spTop], [rSpXL, spTop]], true);
+      } else {
+        const pts = [[rSpXL, spBot], [rSpXR, spBot]];
+        if (rSpTopR > spBot) pts.push([rSpXR, rSpTopR]);
+        if (rSpTopL > spBot) pts.push([rSpXL, rSpTopL]);
+        if (pts.length >= 3) d.drawPolyline(pts, true);
+      }
+    }
+  }
+
+  // ── Footer panels ──
+  for (const f of footers) {
+    d.setActiveLayer('FRAMING');
+    d.drawPolyline([[f.x, 0], [f.x + f.width, 0], [f.x + f.width, f.height], [f.x, f.height]], true);
+    d.setActiveLayer('LABELS');
+    d.drawText(f.x + f.width / 2 - 40, f.height / 2, 28, 0, `Footer ${f.ref}`);
+  }
+
+  // ── Lintels ──
+  for (const l of lintels) {
+    const hL = l.heightLeft != null ? l.heightLeft : l.height;
+    const hR = l.heightRight != null ? l.heightRight : l.height;
+    const yBase = l.y;
+    const yTopL = l.y + hL;
+    const yTopR = l.y + hR;
+
+    d.setActiveLayer('FRAMING');
+    const pts = l.peakHeight
+      ? [[l.x, yBase], [l.x, yTopL], [l.x + l.peakXLocal, l.y + l.peakHeight], [l.x + l.width, yTopR], [l.x + l.width, yBase]]
+      : [[l.x, yBase], [l.x, yTopL], [l.x + l.width, yTopR], [l.x + l.width, yBase]];
+    d.drawPolyline(pts, true);
+
+    // Timber beam
+    const op = openings.find(o => o.ref === l.ref);
+    if (op) {
+      const hasSill = op.y > 0;
+      const beamH = l.beamHeight || 200;
+      const beamLeft = hasSill ? op.x - BOTTOM_PLATE - SPLINE_WIDTH + EPS_INSET : op.x - BOTTOM_PLATE + EPS_INSET;
+      const beamRight = hasSill ? op.x + op.drawWidth + BOTTOM_PLATE + SPLINE_WIDTH - EPS_INSET : op.x + op.drawWidth + BOTTOM_PLATE - EPS_INSET;
+      const beamBot = l.y;
+      const beamTop = l.y + beamH;
+      d.drawPolyline([
+        [beamLeft, beamBot], [beamRight, beamBot],
+        [beamRight, beamTop], [beamLeft, beamTop],
+      ], true);
+    }
+
+    d.setActiveLayer('LABELS');
+    const midH = Math.max(hL, hR, l.peakHeight || 0) / 2;
+    d.drawText(l.x + l.width / 2 - 40, l.y + midH / 2, 28, 0, `Lintel ${l.ref}`);
+  }
+
+  // ── Horizontal splines at course joints ──
+  if (isMultiCourse && courses.length > 1) {
+    d.setActiveLayer('FRAMING');
+    const jointHasSpline = [];
+    for (let i = 0; i < basePanels.length - 1; i++) {
+      const gapCentre = basePanels[i].x + basePanels[i].width + PANEL_GAP / 2;
+      const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+      const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
+      jointHasSpline.push(!insideLintel && !insideFooter);
+    }
+
+    courses.slice(1).forEach((course) => {
+      const joinY = course.y; // DXF Y
+      const spBotY = joinY - HALF_SPLINE;
+      const spTopY = joinY + HALF_SPLINE;
+
+      basePanels.forEach((panel, pi) => {
+        let leftEdge;
+        if (pi > 0 && jointHasSpline[pi - 1]) {
+          const gc = basePanels[pi - 1].x + basePanels[pi - 1].width + PANEL_GAP / 2;
+          leftEdge = gc + HALF_SPLINE;
+        } else {
+          leftEdge = panel.x + BOTTOM_PLATE;
+        }
+        let rightEdge;
+        if (pi < basePanels.length - 1 && jointHasSpline[pi]) {
+          const gc = panel.x + panel.width + PANEL_GAP / 2;
+          rightEdge = gc - HALF_SPLINE;
+        } else {
+          rightEdge = panel.x + panel.width - BOTTOM_PLATE;
+        }
+
+        const splineLeft = leftEdge + HSPLINE_CLEARANCE;
+        const splineRight = rightEdge - HSPLINE_CLEARANCE;
+        const segs = buildHSplineSegments(splineLeft, splineRight, lintels, openings);
+
+        segs.forEach(([segL, segR]) => {
+          if (segR <= segL) return;
+          d.drawPolyline([
+            [segL, spBotY], [segR, spBotY],
+            [segR, spTopY], [segL, spTopY],
+          ], true);
+        });
+      });
+    });
+  }
+
+  // Dimensions
+  drawDimensions(d, layout);
+  drawRunningMeasurement(d, layout);
+
+  return d;
+}
+
+/**
+ * Export framing elevation plan as a DXF file download.
+ */
+export function exportFramingElevationDxf(layout, wallName, projectName) {
+  const d = buildFramingElevationDxf(layout, wallName);
+  const parts = [projectName, wallName, 'Framing Elevation'].filter(Boolean);
+  const filename = parts.join(' ').replace(/\s+/g, ' ').trim() + '.dxf';
+  downloadDxf(d, filename);
+}

--- a/devpro-wall-builder/src/utils/panelPlansDxf.js
+++ b/devpro-wall-builder/src/utils/panelPlansDxf.js
@@ -1,0 +1,343 @@
+/**
+ * DXF export for CNC Panel Plans.
+ *
+ * Generates individual panel cutting profiles laid out in a grid.
+ * Each piece is drawn at 1:1 mm scale with dimension labels.
+ */
+import { WINDOW_OVERHANG, PANEL_GAP, OPENING_TYPES, BOTTOM_PLATE, TOP_PLATE } from './constants.js';
+import { createDrawing, downloadDxf } from './dxfExporter.js';
+
+const SPLINE_WIDTH = 146;
+const HALF_SPLINE = SPLINE_WIDTH / 2;
+
+// ── Profile computation (mirrors PanelPlans.jsx logic) ──
+
+function panelHeightAtLocal(panel, localX) {
+  const hL = panel.heightLeft || panel.height;
+  const hR = panel.heightRight || panel.height;
+  const W = panel.width;
+  if (panel.peakHeight && panel.peakXLocal != null) {
+    if (localX <= panel.peakXLocal) {
+      return panel.peakXLocal > 0
+        ? hL + (panel.peakHeight - hL) * (localX / panel.peakXLocal)
+        : panel.peakHeight;
+    }
+    const remaining = W - panel.peakXLocal;
+    return remaining > 0
+      ? panel.peakHeight + (hR - panel.peakHeight) * ((localX - panel.peakXLocal) / remaining)
+      : panel.peakHeight;
+  }
+  return W > 0 ? hL + (hR - hL) * (localX / W) : hL;
+}
+
+function topEdgeVertices(panel, x1, x2) {
+  const verts = [{ x: x1, y: panelHeightAtLocal(panel, x1) }];
+  if (panel.peakHeight && panel.peakXLocal != null && panel.peakXLocal > x1 && panel.peakXLocal < x2) {
+    verts.push({ x: panel.peakXLocal, y: panel.peakHeight });
+  }
+  verts.push({ x: x2, y: panelHeightAtLocal(panel, x2) });
+  return verts;
+}
+
+function computeLcutProfile(panel) {
+  const hL = panel.heightLeft || panel.height;
+  const hR = panel.heightRight || panel.height;
+  const H = Math.max(hL, hR, panel.peakHeight || 0);
+  const ovh = WINDOW_OVERHANG;
+  const gap = PANEL_GAP;
+
+  if (panel.side === 'pier') return computePierProfile(panel);
+
+  const isLeft = panel.side === 'left';
+  const isWindow = panel.openingType === OPENING_TYPES.WINDOW;
+  const sill = panel.openBottom + gap;
+  const lintelStep = panel.openTop - gap;
+
+  if (isLeft) {
+    const totalW = panel.width;
+    const base = totalW - ovh;
+    const topEdge = topEdgeVertices(panel, 0, base);
+    if (isWindow && sill > 0) {
+      return { vertices: [...topEdge, { x: base, y: lintelStep }, { x: totalW, y: lintelStep }, { x: totalW, y: sill }, { x: base, y: sill }, { x: base, y: 0 }, { x: 0, y: 0 }], profileWidth: totalW, profileHeight: H };
+    }
+    return { vertices: [...topEdge, { x: base, y: lintelStep }, { x: totalW, y: lintelStep }, { x: totalW, y: 0 }, { x: 0, y: 0 }], profileWidth: totalW, profileHeight: H };
+  }
+
+  const totalW = panel.width;
+  const topEdge = topEdgeVertices(panel, ovh, totalW);
+  if (isWindow && sill > 0) {
+    return { vertices: [...topEdge, { x: totalW, y: 0 }, { x: ovh, y: 0 }, { x: ovh, y: sill }, { x: 0, y: sill }, { x: 0, y: lintelStep }, { x: ovh, y: lintelStep }], profileWidth: totalW, profileHeight: H };
+  }
+  return { vertices: [...topEdge, { x: totalW, y: 0 }, { x: 0, y: 0 }, { x: 0, y: lintelStep }, { x: ovh, y: lintelStep }], profileWidth: totalW, profileHeight: H };
+}
+
+function computePierProfile(panel) {
+  const hL = panel.heightLeft || panel.height;
+  const hR = panel.heightRight || panel.height;
+  const H = Math.max(hL, hR, panel.peakHeight || 0);
+  const ovh = WINDOW_OVERHANG;
+  const gap = PANEL_GAP;
+  const totalW = panel.width;
+  const base = totalW - 2 * ovh;
+
+  const lIsWindow = panel.openingType === OPENING_TYPES.WINDOW;
+  const lSill = panel.openBottom + gap;
+  const lLintel = panel.openTop - gap;
+  const rIsWindow = panel.rightOpeningType === OPENING_TYPES.WINDOW;
+  const rSill = panel.rightOpenBottom + gap;
+  const rLintel = panel.rightOpenTop - gap;
+
+  const verts = [];
+  topEdgeVertices(panel, ovh, ovh + base).forEach(v => verts.push(v));
+  verts.push({ x: ovh + base, y: rLintel });
+
+  if (rIsWindow && rSill > 0) {
+    verts.push({ x: totalW, y: rLintel }, { x: totalW, y: rSill }, { x: ovh + base, y: rSill }, { x: ovh + base, y: 0 });
+  } else {
+    verts.push({ x: totalW, y: rLintel }, { x: totalW, y: 0 });
+  }
+
+  verts.push({ x: ovh, y: 0 });
+
+  if (lIsWindow && lSill > 0) {
+    verts.push({ x: ovh, y: lSill }, { x: 0, y: lSill }, { x: 0, y: lLintel }, { x: ovh, y: lLintel });
+  } else {
+    verts.push({ x: ovh, y: lLintel }, { x: 0, y: lLintel }, { x: ovh, y: lLintel });
+  }
+
+  return { vertices: verts, profileWidth: totalW, profileHeight: H };
+}
+
+// ── Collect all pieces from layout ──
+
+function collectPieces(layout) {
+  const panels = layout.panels || [];
+  const isRaked = layout.isRaked;
+  const isMultiCourse = layout.isMultiCourse;
+  const courses = layout.courses || [];
+  const lintels = layout.lintels || [];
+  const footers = layout.footers || [];
+  const openings = layout.openings || [];
+  const dedLeft = layout.deductionLeft || 0;
+  const dedRight = layout.deductionRight || 0;
+  const wallH = layout.height;
+
+  const pieces = [];
+
+  // Deductions
+  if (dedLeft > 0) {
+    pieces.push({ type: 'deduction', label: 'End Wall (left)', vertices: rectVerts(dedLeft, wallH), w: dedLeft, h: wallH, qty: 2 });
+  }
+
+  // Raked full panels
+  if (isRaked) {
+    panels.filter(p => p.type === 'full' && (p.heightLeft !== p.heightRight || p.peakHeight)).forEach(panel => {
+      const hL = panel.heightLeft || panel.height;
+      const hR = panel.heightRight || panel.height;
+      const peakH = panel.peakHeight || 0;
+      const maxH = Math.max(hL, hR, peakH);
+      const verts = panel.peakHeight
+        ? [{ x: 0, y: hL }, { x: panel.peakXLocal, y: panel.peakHeight }, { x: panel.width, y: hR }, { x: panel.width, y: 0 }, { x: 0, y: 0 }]
+        : [{ x: 0, y: hL }, { x: panel.width, y: hR }, { x: panel.width, y: 0 }, { x: 0, y: 0 }];
+      pieces.push({ type: 'full', label: `P${panel.index + 1} — Full${panel.peakHeight ? ' (gable)' : ' (raked)'}`, vertices: verts, w: panel.width, h: maxH, qty: 2 });
+    });
+  }
+
+  // L-cut panels
+  panels.filter(p => p.type === 'lcut').forEach(panel => {
+    const profile = computeLcutProfile(panel);
+    const isPier = panel.side === 'pier';
+    const sideLabel = isPier ? 'pier' : panel.side;
+    pieces.push({ type: 'lcut', label: `P${panel.index + 1} — ${isPier ? 'Pier' : 'L-Cut'} (${sideLabel})`, vertices: profile.vertices, w: profile.profileWidth, h: profile.profileHeight, qty: 2 });
+  });
+
+  // End panels
+  panels.filter(p => p.type === 'end').forEach(panel => {
+    const hL = panel.heightLeft || panel.height;
+    const hR = panel.heightRight || panel.height;
+    const peakH = panel.peakHeight || 0;
+    const maxH = Math.max(hL, hR, peakH);
+    const verts = panel.peakHeight
+      ? [{ x: 0, y: hL }, { x: panel.peakXLocal, y: panel.peakHeight }, { x: panel.width, y: hR }, { x: panel.width, y: 0 }, { x: 0, y: 0 }]
+      : [{ x: 0, y: hL }, { x: panel.width, y: hR }, { x: panel.width, y: 0 }, { x: 0, y: 0 }];
+    pieces.push({ type: 'end', label: `P${panel.index + 1} — End`, vertices: verts, w: panel.width, h: maxH, qty: 2 });
+  });
+
+  if (dedRight > 0) {
+    pieces.push({ type: 'deduction', label: 'End Wall (right)', vertices: rectVerts(dedRight, wallH), w: dedRight, h: wallH, qty: 2 });
+  }
+
+  // Lintels
+  lintels.forEach(l => {
+    const hL = l.heightLeft != null ? l.heightLeft : l.height;
+    const hR = l.heightRight != null ? l.heightRight : l.height;
+    const peakH = l.peakHeight || 0;
+    const H = Math.max(hL, hR, peakH);
+    const verts = l.peakHeight
+      ? [{ x: 0, y: hL }, { x: l.peakXLocal, y: l.peakHeight }, { x: l.width, y: hR }, { x: l.width, y: 0 }, { x: 0, y: 0 }]
+      : [{ x: 0, y: hL }, { x: l.width, y: hR }, { x: l.width, y: 0 }, { x: 0, y: 0 }];
+    pieces.push({ type: 'lintel', label: `${l.ref} — Lintel`, vertices: verts, w: l.width, h: H, qty: 2 });
+  });
+
+  // Footers
+  footers.forEach(f => {
+    pieces.push({ type: 'footer', label: `${f.ref} — Footer`, vertices: rectVerts(f.width, f.height), w: f.width, h: f.height, qty: 2 });
+  });
+
+  // Splines
+  const splineH = wallH - BOTTOM_PLATE - TOP_PLATE * 2 - 10;
+  const splinePieces = [];
+  for (let i = 0; i < panels.length - 1; i++) {
+    const panel = panels[i];
+    const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
+    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
+    if (!insideLintel && !insideFooter) splinePieces.push(1);
+  }
+  for (const op of openings) {
+    if (op.y > 0) { splinePieces.push(1); splinePieces.push(1); }
+  }
+  if (splinePieces.length > 0) {
+    pieces.push({ type: 'spline', label: 'Splines', vertices: rectVerts(SPLINE_WIDTH, splineH), w: SPLINE_WIDTH, h: splineH, qty: splinePieces.length * 2 });
+  }
+
+  // Horizontal splines (multi-course)
+  if (isMultiCourse && courses.length > 1) {
+    const HSPLINE_CLEARANCE = 10;
+    const jointHasSpline = [];
+    for (let i = 0; i < panels.length - 1; i++) {
+      const gapCentre = panels[i].x + panels[i].width + PANEL_GAP / 2;
+      const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+      const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
+      jointHasSpline.push(!insideLintel && !insideFooter);
+    }
+    for (let ci = 0; ci < courses.length - 1; ci++) {
+      for (let pi = 0; pi < panels.length; pi++) {
+        const panel = panels[pi];
+        let leftEdge = panel.x;
+        if (pi > 0 && jointHasSpline[pi - 1]) {
+          leftEdge = panels[pi - 1].x + panels[pi - 1].width + PANEL_GAP / 2 + HALF_SPLINE;
+        }
+        let rightEdge = panel.x + panel.width;
+        if (pi < panels.length - 1 && jointHasSpline[pi]) {
+          rightEdge = panel.x + panel.width + PANEL_GAP / 2 - HALF_SPLINE;
+        }
+        const w = Math.round(rightEdge - leftEdge - 2 * HSPLINE_CLEARANCE);
+        if (w > 0) {
+          pieces.push({ type: 'hspline', label: `H-Spline P${panel.index + 1} C${ci + 1}/${ci + 2}`, vertices: rectVerts(w, SPLINE_WIDTH), w, h: SPLINE_WIDTH, qty: 2 });
+        }
+      }
+    }
+  }
+
+  // Top course panels (multi-course)
+  if (isMultiCourse && courses.length > 1) {
+    const topCoursePanels = panels.filter(p => p.isMultiCourse);
+    courses.slice(1).forEach((course, ci) => {
+      topCoursePanels.forEach(panel => {
+        pieces.push({ type: 'top-course', label: `P${panel.index + 1} — Top Course`, vertices: rectVerts(panel.width, course.height), w: panel.width, h: course.height, qty: 2, subtitle: `from ${course.sheetHeight}mm sheet` });
+      });
+    });
+  }
+
+  return pieces;
+}
+
+function rectVerts(w, h) {
+  return [{ x: 0, y: h }, { x: w, y: h }, { x: w, y: 0 }, { x: 0, y: 0 }];
+}
+
+// ── DXF drawing ──
+
+function drawPiece(d, ox, oy, piece) {
+  const { vertices, w, h, label, qty, subtitle } = piece;
+  const dimOffset = 80;
+
+  // Profile outline
+  d.setActiveLayer('OUTLINE');
+  const pts = vertices.map(v => [ox + v.x, oy + v.y]);
+  d.drawPolyline(pts, true);
+
+  // Dimension labels along edges
+  d.setActiveLayer('DIMENSIONS');
+  for (let i = 0; i < vertices.length; i++) {
+    const a = vertices[i];
+    const b = vertices[(i + 1) % vertices.length];
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const len = Math.round(Math.sqrt(dx * dx + dy * dy));
+    if (len === 0) continue;
+
+    const mx = ox + (a.x + b.x) / 2;
+    const my = oy + (a.y + b.y) / 2;
+
+    if (Math.abs(dy) < 0.1) {
+      // Horizontal edge
+      const isTop = a.y >= h - 0.1;
+      const yOff = isTop ? 30 : -50;
+      d.drawText(mx - 30, my + yOff, 30, 0, `${len}`);
+    } else if (Math.abs(dx) < 0.1) {
+      // Vertical edge
+      const minX = Math.min(...vertices.map(v => v.x));
+      const isLeft = a.x <= minX + 0.1;
+      const xOff = isLeft ? -60 : 30;
+      d.drawText(mx + xOff, my, 30, 90, `${len}`);
+    }
+  }
+
+  // Label
+  d.setActiveLayer('LABELS');
+  const textSize = Math.min(40, w / 6);
+  d.drawText(ox + w / 2 - textSize * label.length / 4, oy + h / 2 + textSize / 2, textSize, 0, label);
+  if (subtitle) {
+    d.drawText(ox + w / 2 - textSize * 3, oy + h / 2 - textSize, textSize * 0.7, 0, subtitle);
+  }
+
+  // Quantity badge
+  if (qty > 1) {
+    d.drawText(ox + w - 80, oy + h - 30, 35, 0, `x${qty}`);
+  }
+}
+
+/**
+ * Build the DXF drawing for CNC panel plans.
+ */
+export function buildPanelPlansDxf(layout, wallName) {
+  const d = createDrawing();
+  const pieces = collectPieces(layout);
+  if (pieces.length === 0) return d;
+
+  const spacing = 300;
+  const maxRowWidth = 10000;
+
+  // Title
+  d.setActiveLayer('LABELS');
+  d.drawText(0, -200, 60, 0, `${wallName || 'Wall'} — CNC Panel Plans`);
+
+  let cursorX = 0;
+  let cursorY = -400;
+  let rowMaxH = 0;
+
+  for (const piece of pieces) {
+    if (cursorX > 0 && cursorX + piece.w > maxRowWidth) {
+      cursorX = 0;
+      cursorY -= rowMaxH + spacing;
+      rowMaxH = 0;
+    }
+    drawPiece(d, cursorX, cursorY - piece.h, piece);
+    rowMaxH = Math.max(rowMaxH, piece.h);
+    cursorX += piece.w + spacing;
+  }
+
+  return d;
+}
+
+/**
+ * Export CNC panel plans as a DXF file download.
+ */
+export function exportPanelPlansDxf(layout, wallName, projectName) {
+  const d = buildPanelPlansDxf(layout, wallName);
+  const parts = [projectName, wallName, 'Panel Plans'].filter(Boolean);
+  const filename = parts.join(' ').replace(/\s+/g, ' ').trim() + '.dxf';
+  downloadDxf(d, filename);
+}


### PR DESCRIPTION
## Summary

- **3D Viewer**: Interactive wall placement with click-to-place, wall-to-wall snapping, select/move/rotate/delete, undo/redo, proper wall profile geometry with opening cutouts and billboard labels
- **DXF Export**: Add DXF export buttons for all plan types — external elevation, framing elevation, EPS elevation, EPS cut plans, and CNC panel plans. Each generates 1:1 mm scale DXF with layered geometry (OUTLINE, FRAMING, EPS, OPENINGS, DIMENSIONS, LABELS)
- **File Naming**: Standardise all print and DXF filenames to `[Project Name] [Wall Name] [Type]` convention

## Test plan

- [ ] Open a project with walls, verify 3D viewer renders walls correctly
- [ ] Place, move, rotate, delete walls in 3D viewer
- [ ] Test wall-to-wall snapping at corners
- [ ] Click each DXF export button, verify .dxf file downloads with correct name
- [ ] Open exported DXF files in a CAD tool (AutoCAD, FreeCAD, etc.)
- [ ] Verify Print A3 defaults to correct filename
- [ ] Test with standard, raked, and gable wall profiles
- [ ] Test with multi-course walls

🤖 Generated with [Claude Code](https://claude.com/claude-code)