### PR TITLE
Rename lintels to lintelPanels and beamHeight to lintelHeight

### DIFF
--- a/devpro-wall-builder/src/components/EpsCutPlans.jsx
+++ b/devpro-wall-builder/src/components/EpsCutPlans.jsx
@@ -90,7 +90,7 @@ export default function EpsCutPlans({ layout, wallName, projectName }) {
   const sectionRef = useRef(null);
   if (!layout) return null;
 
-  const { height, panels, openings, footers, lintels, deductionLeft, deductionRight, courses, isMultiCourse } = layout;
+  const { height, panels, openings, footers, lintelPanels, deductionLeft, deductionRight, courses, isMultiCourse } = layout;
 
   const isRaked = layout.isRaked;
 
@@ -113,7 +113,7 @@ export default function EpsCutPlans({ layout, wallName, projectName }) {
   for (let i = 0; i < panels.length - 1; i++) {
     const panel = panels[i];
     const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
-    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
     const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
     if (!insideLintel && !insideFooter) {
       exclusions.push([gapCentre - HALF_SPLINE, gapCentre + HALF_SPLINE]);
@@ -145,7 +145,7 @@ export default function EpsCutPlans({ layout, wallName, projectName }) {
     }
   }
 
-  for (const l of lintels) {
+  for (const l of lintelPanels) {
     exclusions.push([l.x, l.x + l.width]);
   }
 
@@ -249,7 +249,7 @@ export default function EpsCutPlans({ layout, wallName, projectName }) {
   for (let i = 0; i < panels.length - 1; i++) {
     const panel = panels[i];
     const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
-    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
     const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
     if (!insideLintel && !insideFooter) {
       splinePieces.push({ label: `Joint P${panels[i].index + 1}/P${panels[i + 1].index + 1}`, width: SPLINE_WIDTH, height: splineH });

--- a/devpro-wall-builder/src/components/EpsElevation.jsx
+++ b/devpro-wall-builder/src/components/EpsElevation.jsx
@@ -21,7 +21,7 @@ export default function EpsElevation({ layout, wallName, projectName }) {
   const clipId = useRef(`eps-clip-${Math.random().toString(36).slice(2, 8)}`).current;
   if (!layout) return null;
 
-  const { grossLength, height, maxHeight, panels, openings, footers, lintels, deductionLeft, deductionRight, isRaked, heightAt, courses, isMultiCourse } = layout;
+  const { grossLength, height, maxHeight, panels, openings, footers, lintelPanels, deductionLeft, deductionRight, isRaked, heightAt, courses, isMultiCourse } = layout;
 
   const useHeight = maxHeight || height;
   const drawWidth = MAX_SVG_WIDTH - MARGIN.left - MARGIN.right;
@@ -58,7 +58,7 @@ export default function EpsElevation({ layout, wallName, projectName }) {
     const panel = basePanels[i];
     const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
     // Skip if inside opening zone (same logic as framing elevation)
-    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
     const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
     if (!insideLintel && !insideFooter) {
       exclusions.push([gapCentre - HALF_SPLINE, gapCentre + HALF_SPLINE]);
@@ -97,8 +97,8 @@ export default function EpsElevation({ layout, wallName, projectName }) {
     }
   }
 
-  // 5. Lintel areas (no EPS — timber lintels)
-  for (const l of lintels) {
+  // 5. Lintel panel areas (lintel panels sit above timber lintels)
+  for (const l of lintelPanels) {
     exclusions.push([l.x, l.x + l.width]);
   }
 
@@ -255,7 +255,7 @@ export default function EpsElevation({ layout, wallName, projectName }) {
 
             const getVertExclusions = (xEdge) => {
               const zones = [];
-              for (const l of lintels) {
+              for (const l of lintelPanels) {
                 if (l.x < xEdge && xEdge < l.x + l.width) {
                   const hL = l.heightLeft != null ? l.heightLeft : l.height;
                   const hR = l.heightRight != null ? l.heightRight : l.height;
@@ -556,7 +556,7 @@ export default function EpsElevation({ layout, wallName, projectName }) {
           })}
 
           {/* ── Lintels (timber beam + EPS fill above) ── */}
-          {lintels.map((l, i) => {
+          {lintelPanels.map((l, i) => {
             const hL = l.heightLeft != null ? l.heightLeft : l.height;
             const hR = l.heightRight != null ? l.heightRight : l.height;
             const x1 = s(l.x);
@@ -574,33 +574,33 @@ export default function EpsElevation({ layout, wallName, projectName }) {
 
             const midH = Math.max(hL, hR, l.peakHeight || 0) / 2;
 
-            // Timber beam and EPS fill (only when matching opening exists)
-            let beamLeft, beamRight, beamTop, beamH;
+            // Timber lintel and EPS fill (only when matching opening exists)
+            let lintelLeft, lintelRight, lintelTop, lintelH;
             let epsPoly = null;
             if (op) {
-              // Timber beam spans between inner edges of opening splines/plates, with 10mm gap
-              beamH = l.beamHeight || 200;
-              beamLeft = hasSill
+              // Timber lintel spans between inner edges of opening splines/plates, with 10mm gap
+              lintelH = l.lintelHeight || 200;
+              lintelLeft = hasSill
                 ? op.x - BOTTOM_PLATE - SPLINE_WIDTH + EPS_INSET  // 10mm inside left spline outer edge
                 : op.x - BOTTOM_PLATE + EPS_INSET;                // 10mm inside left plate inner edge
-              beamRight = hasSill
+              lintelRight = hasSill
                 ? op.x + op.drawWidth + BOTTOM_PLATE + SPLINE_WIDTH - EPS_INSET  // 10mm inside right spline outer edge
                 : op.x + op.drawWidth + BOTTOM_PLATE - EPS_INSET;               // 10mm inside right plate inner edge
-              beamTop = yBottom - l.y - beamH;
+              lintelTop = yBottom - l.y - lintelH;
 
-              // Lintel EPS: fills the area above the timber beam, inset 10mm from spline/plate inner edges
+              // Lintel panel EPS: fills the area above the timber lintel, inset 10mm from spline/plate inner edges
               const epsLeft = hasSill
                 ? op.x - BOTTOM_PLATE - SPLINE_WIDTH + EPS_INSET  // 10mm inside spline outer edge
                 : op.x - BOTTOM_PLATE + EPS_INSET;                // 10mm inside plate inner edge
               const epsRight = hasSill
                 ? op.x + op.drawWidth + BOTTOM_PLATE + SPLINE_WIDTH - EPS_INSET  // 10mm inside spline outer edge
                 : op.x + op.drawWidth + BOTTOM_PLATE - EPS_INSET;               // 10mm inside plate inner edge
-              const epsBot = beamTop - EPS_INSET;  // 10mm above timber beam
+              const epsBot = lintelTop - EPS_INSET;  // 10mm above timber lintel
 
               // EPS top follows wall slope (same as panel EPS logic)
               const epsTopAt = (x) => yTopAt(x) + TOP_PLATE * 2 + EPS_INSET;
 
-              // Build EPS polygon (if there's space above the beam)
+              // Build EPS polygon (if there's space above the lintel)
               if (epsBot > epsTopAt(epsLeft) || epsBot > epsTopAt(epsRight)) {
                 const epsTopL = epsTopAt(epsLeft);
                 const epsTopR = epsTopAt(epsRight);
@@ -641,18 +641,18 @@ export default function EpsElevation({ layout, wallName, projectName }) {
             }
 
             return (
-              <g key={`lintel-${i}`}>
-                {/* Lintel outline */}
+              <g key={`lintel-panel-${i}`}>
+                {/* Lintel panel outline */}
                 <polygon points={outlinePts} fill="none" stroke={STROKE_COLOR} strokeWidth={1} />
-                {/* Timber beam */}
+                {/* Timber lintel */}
                 {op && (
                   <rect
-                    x={s(beamLeft)} y={s(beamTop)}
-                    width={s(beamRight - beamLeft)} height={s(beamH)}
+                    x={s(lintelLeft)} y={s(lintelTop)}
+                    width={s(lintelRight - lintelLeft)} height={s(lintelH)}
                     fill="none" stroke={STROKE_COLOR} strokeWidth={1}
                   />
                 )}
-                {/* EPS above beam */}
+                {/* EPS above lintel */}
                 {epsPoly}
                 <text
                   x={s(l.x + l.width / 2)}
@@ -674,7 +674,7 @@ export default function EpsElevation({ layout, wallName, projectName }) {
             for (let i = 0; i < basePanels.length - 1; i++) {
               const panel = basePanels[i];
               const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
-              const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+              const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
               const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
               if (!insideLintel && !insideFooter) {
                 splines.push({ xPos: gapCentre - HALF_SPLINE, cx: gapCentre });
@@ -733,7 +733,7 @@ export default function EpsElevation({ layout, wallName, projectName }) {
             const jointHasSpline = [];
             for (let i = 0; i < basePanels.length - 1; i++) {
               const gapCentre = basePanels[i].x + basePanels[i].width + PANEL_GAP / 2;
-              const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+              const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
               const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
               jointHasSpline.push(!insideLintel && !insideFooter);
             }
@@ -759,10 +759,10 @@ export default function EpsElevation({ layout, wallName, projectName }) {
                   rightEdge = panel.x + panel.width - BOTTOM_PLATE;
                 }
 
-                // Split around lintels, openings, opening plates & splines
+                // Split around lintel panels, openings, opening plates & splines
                 const splineLeft = leftEdge + HSPLINE_CLEARANCE;
                 const splineRight = rightEdge - HSPLINE_CLEARANCE;
-                const segs = buildHSplineSegments(splineLeft, splineRight, lintels, openings);
+                const segs = buildHSplineSegments(splineLeft, splineRight, lintelPanels, openings);
                 if (segs.length === 0) return null;
 
                 return segs.map(([segL, segR], si) => {

--- a/devpro-wall-builder/src/components/FramingElevation.jsx
+++ b/devpro-wall-builder/src/components/FramingElevation.jsx
@@ -18,7 +18,7 @@ export default function FramingElevation({ layout, wallName, projectName }) {
   const sectionRef = useRef(null);
   if (!layout) return null;
 
-  const { grossLength, height, maxHeight, panels, openings, footers, lintels, deductionLeft, deductionRight, isRaked, heightAt, courses, isMultiCourse } = layout;
+  const { grossLength, height, maxHeight, panels, openings, footers, lintelPanels, deductionLeft, deductionRight, isRaked, heightAt, courses, isMultiCourse } = layout;
 
   const drawWidth = MAX_SVG_WIDTH - MARGIN.left - MARGIN.right;
   const scale = drawWidth / grossLength;
@@ -205,7 +205,7 @@ export default function FramingElevation({ layout, wallName, projectName }) {
           )}
 
           {/* ── Panels ── */}
-          {/* Draw panel edges as individual lines, skipping lintel/footer zones */}
+          {/* Draw panel edges as individual lines, skipping lintel panel/footer zones */}
           {/* Use course 0 panels for structural lines (same x-positions across courses) */}
           {(() => {
             const basePanels = panels.filter(p => (p.course ?? 0) === 0);
@@ -217,7 +217,7 @@ export default function FramingElevation({ layout, wallName, projectName }) {
                 {basePanels.map((panel, i) => {
                   const getExclusions = (xEdge) => {
                     const zones = [];
-                    for (const l of lintels) {
+                    for (const l of lintelPanels) {
                       if (l.x < xEdge && xEdge < l.x + l.width) {
                         const hL = l.heightLeft != null ? l.heightLeft : l.height;
                         const hR = l.heightRight != null ? l.heightRight : l.height;
@@ -358,11 +358,11 @@ export default function FramingElevation({ layout, wallName, projectName }) {
           })()}
 
           {/* ── Panel joint splines (146mm centred on 5mm gap) ── */}
-          {/* Skip joints that fall inside a lintel or footer (opening zones) */}
+          {/* Skip joints that fall inside a lintel panel or footer (opening zones) */}
           {/* Use course 0 panels — x-positions are identical across courses */}
           {panels.filter(p => (p.course ?? 0) === 0).slice(0, -1).map((panel, i) => {
             const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
-            const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+            const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
             const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
             if (insideLintel || insideFooter) return null;
 
@@ -481,8 +481,8 @@ export default function FramingElevation({ layout, wallName, projectName }) {
             </g>
           ))}
 
-          {/* ── Lintels (trapezoid for raked/gable, with timber beam) ── */}
-          {lintels.map((l, i) => {
+          {/* ── Lintel panels (trapezoid for raked/gable, with timber lintel) ── */}
+          {lintelPanels.map((l, i) => {
             const hL = l.heightLeft != null ? l.heightLeft : l.height;
             const hR = l.heightRight != null ? l.heightRight : l.height;
             const x1 = s(l.x);
@@ -495,25 +495,25 @@ export default function FramingElevation({ layout, wallName, projectName }) {
               : `${x1},${yBase} ${x1},${yTopL} ${x2},${yTopR} ${x2},${yBase}`;
             const midH = Math.max(hL, hR, l.peakHeight || 0) / 2;
 
-            // Timber beam rect (spans between vertical plates/splines with EPS_INSET gap)
+            // Timber lintel rect (spans between vertical plates/splines with EPS_INSET gap)
             const op = openings.find(o => o.ref === l.ref);
             const hasSill = op && op.y > 0;
-            const beamH = l.beamHeight || 200;
-            let beamEl = null;
+            const lintelH = l.lintelHeight || 200;
+            let lintelEl = null;
             if (op) {
-              const beamLeft = hasSill
+              const lintelLeft = hasSill
                 ? op.x - BOTTOM_PLATE - SPLINE_WIDTH + EPS_INSET
                 : op.x - BOTTOM_PLATE + EPS_INSET;
-              const beamRight = hasSill
+              const lintelRight = hasSill
                 ? op.x + op.drawWidth + BOTTOM_PLATE + SPLINE_WIDTH - EPS_INSET
                 : op.x + op.drawWidth + BOTTOM_PLATE - EPS_INSET;
-              const beamTop = yBottom - l.y - beamH;
-              const beamW = beamRight - beamLeft;
-              if (beamW > 0 && beamH > 0) {
-                beamEl = (
+              const lintelTop = yBottom - l.y - lintelH;
+              const lintelW = lintelRight - lintelLeft;
+              if (lintelW > 0 && lintelH > 0) {
+                lintelEl = (
                   <rect
-                    x={s(beamLeft)} y={s(beamTop)}
-                    width={s(beamW)} height={s(beamH)}
+                    x={s(lintelLeft)} y={s(lintelTop)}
+                    width={s(lintelW)} height={s(lintelH)}
                     fill="none" stroke={STROKE_COLOR} strokeWidth={1} strokeDasharray={DASH}
                   />
                 );
@@ -523,7 +523,7 @@ export default function FramingElevation({ layout, wallName, projectName }) {
             return (
               <g key={`lintel-${i}`}>
                 <polygon points={pts} fill="none" stroke={STROKE_COLOR} strokeWidth={1} strokeDasharray={DASH} />
-                {beamEl}
+                {lintelEl}
                 <text
                   x={s(l.x + l.width / 2)}
                   y={s(yBottom - l.y - midH / 2) + 3}
@@ -642,7 +642,7 @@ export default function FramingElevation({ layout, wallName, projectName }) {
             const jointHasSpline = [];
             for (let i = 0; i < basePanels.length - 1; i++) {
               const gapCentre = basePanels[i].x + basePanels[i].width + PANEL_GAP / 2;
-              const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+              const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
               const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
               jointHasSpline.push(!insideLintel && !insideFooter);
             }
@@ -670,7 +670,7 @@ export default function FramingElevation({ layout, wallName, projectName }) {
 
                 const splineLeft = leftEdge + HSPLINE_CLEARANCE;
                 const splineRight = rightEdge - HSPLINE_CLEARANCE;
-                const segs = buildHSplineSegments(splineLeft, splineRight, lintels, openings);
+                const segs = buildHSplineSegments(splineLeft, splineRight, lintelPanels, openings);
                 if (segs.length === 0) return null;
 
                 return segs.map(([segL, segR], si) => {

--- a/devpro-wall-builder/src/components/MagboardSheetSummary.jsx
+++ b/devpro-wall-builder/src/components/MagboardSheetSummary.jsx
@@ -15,7 +15,7 @@ export default function MagboardSheetSummary({ walls }) {
     panelSheetCount, panelSheets2745, panelSheets3050,
     cutPieceCount, cutSheets2745, cutSheets3050, cutUtilization,
     total2745, total3050, totalSheets,
-    totalLintels, totalFooters, totalSplines, totalDeductions,
+    totalLintelPanels, totalFooters, totalSplines, totalDeductions,
     perWall,
   } = result;
 
@@ -83,7 +83,7 @@ export default function MagboardSheetSummary({ walls }) {
                       <td style={styles.td}>Splines (146mm wide)</td>
                       <td style={{ ...styles.td, textAlign: 'right' }}>{totalSplines}</td>
                       <td style={{ ...styles.td, textAlign: 'right' }} rowSpan={
-                        [totalSplines, totalLintels, totalFooters, totalDeductions].filter(Boolean).length
+                        [totalSplines, totalLintelPanels, totalFooters, totalDeductions].filter(Boolean).length
                       }>
                         <div style={{ display: 'flex', alignItems: 'center', gap: 6, justifyContent: 'flex-end' }}>
                           {cutSheets2745 + cutSheets3050}
@@ -92,10 +92,10 @@ export default function MagboardSheetSummary({ walls }) {
                       </td>
                     </tr>
                   )}
-                  {totalLintels > 0 && (
+                  {totalLintelPanels > 0 && (
                     <tr style={styles.evenRow}>
-                      <td style={styles.td}>Lintels</td>
-                      <td style={{ ...styles.td, textAlign: 'right' }}>{totalLintels}</td>
+                      <td style={styles.td}>Lintel Panels</td>
+                      <td style={{ ...styles.td, textAlign: 'right' }}>{totalLintelPanels}</td>
                     </tr>
                   )}
                   {totalFooters > 0 && (
@@ -124,7 +124,7 @@ export default function MagboardSheetSummary({ walls }) {
                   <th style={styles.th}>Wall</th>
                   <th style={{ ...styles.th, textAlign: 'right' }}>Panel Sheets</th>
                   <th style={{ ...styles.th, textAlign: 'right' }}>Splines</th>
-                  <th style={{ ...styles.th, textAlign: 'right' }}>Lintels</th>
+                  <th style={{ ...styles.th, textAlign: 'right' }}>Lintel Panels</th>
                   <th style={{ ...styles.th, textAlign: 'right' }}>Footers</th>
                 </tr>
               </thead>
@@ -134,7 +134,7 @@ export default function MagboardSheetSummary({ walls }) {
                     <td style={{ ...styles.td, fontWeight: 600 }}>{w.wallName}</td>
                     <td style={{ ...styles.td, textAlign: 'right' }}>{w.panelSheetCount}</td>
                     <td style={{ ...styles.td, textAlign: 'right' }}>{w.splineCount}</td>
-                    <td style={{ ...styles.td, textAlign: 'right' }}>{w.lintelCount}</td>
+                    <td style={{ ...styles.td, textAlign: 'right' }}>{w.lintelPanelCount}</td>
                     <td style={{ ...styles.td, textAlign: 'right' }}>{w.footerCount}</td>
                   </tr>
                 ))}
@@ -145,7 +145,7 @@ export default function MagboardSheetSummary({ walls }) {
           <div style={styles.sheetInfo}>
             Sheets: 1200 × 2745mm or 3050mm (10mm thick).
             Each panel uses 2 full sheets (front + back face).
-            Splines, lintels, footers, and deductions are bin-packed onto additional sheets.
+            Splines, lintel panels, footers, and deductions are bin-packed onto additional sheets.
           </div>
         </div>
       )}

--- a/devpro-wall-builder/src/components/Offcuts.jsx
+++ b/devpro-wall-builder/src/components/Offcuts.jsx
@@ -113,7 +113,7 @@ function computeOffcuts(layout) {
     }
   }
 
-  // ── Lintel & footer offcuts (cut from 2440 × 1200 sheets) ──
+  // ── Lintel panel & footer offcuts (cut from 2440 × 1200 sheets) ──
   // Piece is rotated so its long dimension runs along the 2440mm sheet height.
   // Two rectangular offcuts from the L-shaped remainder:
   //   Strip A (full-width beside): sheetH × (sheetW - shortDim)
@@ -122,7 +122,7 @@ function computeOffcuts(layout) {
   const SHEET_W = PANEL_WIDTH;    // 1200
 
   const sheetPieces = [
-    ...(layout.lintels || []).map(l => ({ w: l.width, h: l.height, source: `Lintel ${l.ref}` })),
+    ...(layout.lintelPanels || []).map(l => ({ w: l.width, h: l.height, source: `Lintel Panel ${l.ref}` })),
     ...(layout.footers || []).map(f => ({ w: f.width, h: f.height, source: `Footer ${f.ref}` })),
   ];
 

--- a/devpro-wall-builder/src/components/PanelPlans.jsx
+++ b/devpro-wall-builder/src/components/PanelPlans.jsx
@@ -345,7 +345,7 @@ function LcutPlanCard({ panel, courseLineY }) {
 }
 
 /**
- * Lintel plan card — trapezoid for raked/gable, pentagon if straddling gable peak.
+ * Lintel panel plan card — trapezoid for raked/gable, pentagon if straddling gable peak.
  */
 function LintelPlanCard({ lintel }) {
   const W = lintel.width;
@@ -373,7 +373,7 @@ function LintelPlanCard({ lintel }) {
       profileWidth={W}
       profileHeight={H}
       fill={COLORS.LINTEL}
-      title={`${lintel.ref} — Lintel`}
+      title={`${lintel.ref} — Lintel Panel`}
       qty={2}
       peakXLocal={lintel.peakHeight ? lintel.peakXLocal : undefined}
       peakHeight={lintel.peakHeight}
@@ -609,7 +609,7 @@ export default function PanelPlans({ layout, wallName, projectName }) {
   const rakedFullPanels = isRaked
     ? panels.filter(p => p.type === 'full' && (p.heightLeft !== p.heightRight || p.peakHeight))
     : [];
-  const lintels = layout.lintels || [];
+  const lintelPanels = layout.lintelPanels || [];
   const footers = layout.footers || [];
   const openings = layout.openings || [];
   const dedLeft = layout.deductionLeft || 0;
@@ -624,7 +624,7 @@ export default function PanelPlans({ layout, wallName, projectName }) {
   for (let i = 0; i < panels.length - 1; i++) {
     const panel = panels[i];
     const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
-    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
     const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
     if (!insideLintel && !insideFooter) {
       splinePieces.push({ label: `Spline P${panels[i].index + 1}/P${panels[i + 1].index + 1}` });
@@ -646,7 +646,7 @@ export default function PanelPlans({ layout, wallName, projectName }) {
     const jointHasSpline = [];
     for (let i = 0; i < panels.length - 1; i++) {
       const gapCentre = panels[i].x + panels[i].width + PANEL_GAP / 2;
-      const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+      const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
       const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
       jointHasSpline.push(!insideLintel && !insideFooter);
     }
@@ -679,7 +679,7 @@ export default function PanelPlans({ layout, wallName, projectName }) {
   const upperCourses = courses.length > 1 ? courses.slice(1) : [];
 
   const hasContent = lcutPanels.length || endPanels.length || rakedFullPanels.length
-    || lintels.length || footers.length || dedLeft > 0 || dedRight > 0 || splinePieces.length
+    || lintelPanels.length || footers.length || dedLeft > 0 || dedRight > 0 || splinePieces.length
     || topCoursePanels.length || hsplinePieces.length;
   if (!hasContent) return null;
 
@@ -728,8 +728,8 @@ export default function PanelPlans({ layout, wallName, projectName }) {
         {dedRight > 0 && (
           <DeductionCard side="right" width={dedRight} height={wallH} />
         )}
-        {lintels.map((lintel, i) => (
-          <LintelPlanCard key={`lintel-${i}`} lintel={lintel} />
+        {lintelPanels.map((lintel, i) => (
+          <LintelPlanCard key={`lintel-panel-${i}`} lintel={lintel} />
         ))}
         {footers.map((footer, i) => (
           <FooterPlanCard key={`footer-${i}`} footer={footer} />

--- a/devpro-wall-builder/src/components/WallDrawing.jsx
+++ b/devpro-wall-builder/src/components/WallDrawing.jsx
@@ -11,7 +11,7 @@ export default function WallDrawing({ layout, wallName, projectName }) {
   if (!layout) return null;
 
   const {
-    grossLength, height, maxHeight, panels, openings, footers, lintels,
+    grossLength, height, maxHeight, panels, openings, footers, lintelPanels,
     deductionLeft, deductionRight, isRaked, heightAt, profile,
     courses, isMultiCourse,
   } = layout;
@@ -213,8 +213,8 @@ export default function WallDrawing({ layout, wallName, projectName }) {
             </g>
           ))}
 
-          {/* Lintels (trapezoid for raked/gable) */}
-          {lintels.map((l, i) => {
+          {/* Lintel panels (trapezoid for raked/gable) */}
+          {lintelPanels.map((l, i) => {
             const hL = l.heightLeft != null ? l.heightLeft : l.height;
             const hR = l.heightRight != null ? l.heightRight : l.height;
             const x1 = s(l.x);
@@ -389,7 +389,7 @@ export default function WallDrawing({ layout, wallName, projectName }) {
             { color: COLORS.LCUT, label: 'L-Cut Panel' },
             { color: COLORS.END_CAP, label: 'End Panel' },
             { color: COLORS.FOOTER, label: 'Footer' },
-            { color: COLORS.LINTEL, label: 'Lintel' },
+            { color: COLORS.LINTEL, label: 'Lintel Panel' },
           ].map((item, i) => (
             <g key={i} transform={`translate(${i * 120}, 0)`}>
               <rect x={0} y={-8} width={12} height={12} fill={item.color} opacity={0.7} stroke="#666" strokeWidth={0.5} />

--- a/devpro-wall-builder/src/components/WallSummary.jsx
+++ b/devpro-wall-builder/src/components/WallSummary.jsx
@@ -35,7 +35,7 @@ export default function WallSummary({ layout, wallName, projectName }) {
   const sectionRef = useRef(null);
   if (!layout) return null;
 
-  const { panels, openings, lintels, footers, height, deductionLeft, deductionRight, grossLength, isRaked, courses, isMultiCourse } = layout;
+  const { panels, openings, lintelPanels, footers, height, deductionLeft, deductionRight, grossLength, isRaked, courses, isMultiCourse } = layout;
 
   // ── Count splines ──
   // Use course 0 panels for joint detection (same x-positions across courses)
@@ -43,7 +43,7 @@ export default function WallSummary({ layout, wallName, projectName }) {
   const jointSplines = [];
   for (let i = 0; i < basePanels.length - 1; i++) {
     const gapCentre = basePanels[i].x + basePanels[i].width + PANEL_GAP / 2;
-    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
     const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
     if (!insideLintel && !insideFooter) jointSplines.push(gapCentre);
   }
@@ -77,7 +77,7 @@ export default function WallSummary({ layout, wallName, projectName }) {
     if (deductionLeft === 0 && Math.abs(p.x) < 1) exclusions.push([0, BOTTOM_PLATE]);
   }
 
-  for (const l of lintels) exclusions.push([l.x, l.x + l.width]);
+  for (const l of lintelPanels) exclusions.push([l.x, l.x + l.width]);
 
   exclusions.sort((a, b) => a[0] - b[0]);
 
@@ -216,7 +216,7 @@ export default function WallSummary({ layout, wallName, projectName }) {
               <Row label="End Panels" value={layout.endPanels} />
               <Row label="Openings" value={openings.length} />
               <Row label="Footers" value={footers.length} />
-              <Row label="Lintels" value={lintels.length} />
+              <Row label="Lintel Panels" value={lintelPanels.length} />
               <Row label="Splines" value={splineCount} />
             </tbody>
           </table>

--- a/devpro-wall-builder/src/utils/calculator.js
+++ b/devpro-wall-builder/src/utils/calculator.js
@@ -161,7 +161,7 @@ export function calculateWallLayout(wall) {
   // Process openings
   const openingDetails = [];
   const footers = [];
-  const lintels = [];
+  const lintelPanels = [];
   const sortedOpenings = [...(wall.openings || [])].sort(
     (a, b) => a.position_from_left_mm - b.position_from_left_mm
   );
@@ -192,14 +192,14 @@ export function calculateWallLayout(wall) {
       });
     }
 
-    // Lintel follows the wall slope — trapezoid for raked/gable, pentagon if straddling gable peak
+    // Lintel panel follows the wall slope — trapezoid for raked/gable, pentagon if straddling gable peak
     const lintelOverhang = WINDOW_OVERHANG;
     const lintelLeft = openLeft - lintelOverhang;
     const lintelRight = openRight + lintelOverhang;
     const lHeightLeft = Math.max(0, heightAt(lintelLeft) - openTop);
     const lHeightRight = Math.max(0, heightAt(lintelRight) - openTop);
 
-    // Detect gable peak within lintel span
+    // Detect gable peak within lintel panel span
     let lPeakHeight, lPeakXLocal;
     if (profile === WALL_PROFILES.GABLE) {
       const peakX = wall.peak_position_mm ?? Math.round(grossLength / 2);
@@ -209,7 +209,7 @@ export function calculateWallLayout(wall) {
       }
     }
 
-    lintels.push({
+    lintelPanels.push({
       ref: opening.ref,
       x: lintelLeft,
       y: openTop,
@@ -219,8 +219,8 @@ export function calculateWallLayout(wall) {
       heightRight: lHeightRight,
       peakHeight: lPeakHeight,
       peakXLocal: lPeakXLocal,
-      beamHeight: opening.lintel_height_mm ?? 200,
-      type: 'lintel',
+      lintelHeight: opening.lintel_height_mm ?? 200,
+      type: 'lintelPanel',
     });
   }
 
@@ -598,7 +598,7 @@ export function calculateWallLayout(wall) {
     panels: allPanels,
     openings: openingDetails,
     footers,
-    lintels,
+    lintelPanels,
     courses,
     isMultiCourse,
     totalPanels: allPanels.length,

--- a/devpro-wall-builder/src/utils/constants.js
+++ b/devpro-wall-builder/src/utils/constants.js
@@ -76,19 +76,19 @@ export const COLORS = {
 
 /**
  * Build horizontal spline segments within [splineLeft, splineRight],
- * excluding zones around lintels and openings (with their plates/splines).
+ * excluding zones around lintel panels and openings (with their plates/splines).
  *
  * @param {number} splineLeft  - left boundary (already inset by HSPLINE_CLEARANCE)
  * @param {number} splineRight - right boundary (already inset by HSPLINE_CLEARANCE)
- * @param {Array} lintels  - lintel objects with { x, width }
+ * @param {Array} lintelPanels  - lintel panel objects with { x, width }
  * @param {Array} openings - opening objects with { x, drawWidth, y }
  * @returns {Array<[number, number]>} segments as [left, right] pairs
  */
-export function buildHSplineSegments(splineLeft, splineRight, lintels, openings) {
+export function buildHSplineSegments(splineLeft, splineRight, lintelPanels, openings) {
   if (splineRight <= splineLeft) return [];
 
   const excl = [];
-  for (const l of lintels) {
+  for (const l of lintelPanels) {
     const eL = Math.max(l.x - HSPLINE_CLEARANCE, splineLeft);
     const eR = Math.min(l.x + l.width + HSPLINE_CLEARANCE, splineRight);
     if (eL < eR) excl.push([eL, eR]);

--- a/devpro-wall-builder/src/utils/epsElevationDxf.js
+++ b/devpro-wall-builder/src/utils/epsElevationDxf.js
@@ -23,7 +23,7 @@ const MAGBOARD = 10;
 export function buildEpsElevationDxf(layout, wallName) {
   const d = createDrawing();
   const {
-    grossLength, height, maxHeight, panels, openings, footers, lintels,
+    grossLength, height, maxHeight, panels, openings, footers, lintelPanels,
     deductionLeft, deductionRight, isRaked, heightAt, courses, isMultiCourse,
   } = layout;
 
@@ -65,7 +65,7 @@ export function buildEpsElevationDxf(layout, wallName) {
   for (let i = 0; i < basePanels.length - 1; i++) {
     const panel = basePanels[i];
     const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
-    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
     const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
     if (!insideLintel && !insideFooter) {
       exclusions.push([gapCentre - HALF_SPLINE, gapCentre + HALF_SPLINE]);
@@ -87,7 +87,7 @@ export function buildEpsElevationDxf(layout, wallName) {
     if (deductionLeft === 0 && Math.abs(p.x) < 1) exclusions.push([0, BOTTOM_PLATE]);
   }
 
-  for (const l of lintels) exclusions.push([l.x, l.x + l.width]);
+  for (const l of lintelPanels) exclusions.push([l.x, l.x + l.width]);
   exclusions.sort((a, b) => a[0] - b[0]);
 
   const getEpsSegments = (panelLeft, panelRight) => {
@@ -248,8 +248,8 @@ export function buildEpsElevationDxf(layout, wallName) {
     d.drawText(f.x + f.width / 2 - 40, f.height / 2, 30, 0, `Footer ${f.ref}`);
   });
 
-  // ── Lintels ──
-  lintels.forEach((l) => {
+  // ── Lintel panels ──
+  lintelPanels.forEach((l) => {
     const hL = l.heightLeft != null ? l.heightLeft : l.height;
     const hR = l.heightRight != null ? l.heightRight : l.height;
     const yBase = l.y;
@@ -262,24 +262,24 @@ export function buildEpsElevationDxf(layout, wallName) {
       : [[l.x, yBase], [l.x, yTopL], [l.x + l.width, yTopR], [l.x + l.width, yBase]];
     d.drawPolyline(pts, true);
 
-    // Timber beam
+    // Timber lintel
     const op = openings.find(o => o.ref === l.ref);
     if (op) {
       const hasSill = op.y > 0;
-      const beamH = l.beamHeight || 200;
-      const beamLeft = hasSill ? op.x - BOTTOM_PLATE - SPLINE_WIDTH + EPS_INSET : op.x - BOTTOM_PLATE + EPS_INSET;
-      const beamRight = hasSill ? op.x + op.drawWidth + BOTTOM_PLATE + SPLINE_WIDTH - EPS_INSET : op.x + op.drawWidth + BOTTOM_PLATE - EPS_INSET;
-      const beamBot = l.y;
-      const beamTop = l.y + beamH;
+      const lintelH = l.lintelHeight || 200;
+      const lintelLeft = hasSill ? op.x - BOTTOM_PLATE - SPLINE_WIDTH + EPS_INSET : op.x - BOTTOM_PLATE + EPS_INSET;
+      const lintelRight = hasSill ? op.x + op.drawWidth + BOTTOM_PLATE + SPLINE_WIDTH - EPS_INSET : op.x + op.drawWidth + BOTTOM_PLATE - EPS_INSET;
+      const lintelBot = l.y;
+      const lintelTop = l.y + lintelH;
       d.drawPolyline([
-        [beamLeft, beamBot], [beamRight, beamBot],
-        [beamRight, beamTop], [beamLeft, beamTop],
+        [lintelLeft, lintelBot], [lintelRight, lintelBot],
+        [lintelRight, lintelTop], [lintelLeft, lintelTop],
       ], true);
 
-      // EPS above beam
-      const epsBot = beamTop + EPS_INSET;
-      const epsLeft = beamLeft;
-      const epsRight = beamRight;
+      // EPS above timber lintel
+      const epsBot = lintelTop + EPS_INSET;
+      const epsLeft = lintelLeft;
+      const epsRight = lintelRight;
       const epsTopAtX = (x) => hAt(x) - TOP_PLATE * 2 - EPS_INSET;
       const epsTopL = epsTopAtX(epsLeft);
       const epsTopR = epsTopAtX(epsRight);
@@ -321,7 +321,7 @@ export function buildEpsElevationDxf(layout, wallName) {
   for (let i = 0; i < basePanels.length - 1; i++) {
     const panel = basePanels[i];
     const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
-    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
     const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
     if (insideLintel || insideFooter) continue;
 

--- a/devpro-wall-builder/src/utils/epsOptimizer.js
+++ b/devpro-wall-builder/src/utils/epsOptimizer.js
@@ -41,7 +41,7 @@ export const SPLINE_SLABS_PER_BLOCK = Math.floor(EPS_BLOCK.depth / SPLINE_EPS_DE
 export function extractEpsPieces(layout, wallName = '') {
   const pieces = [];
   const {
-    height, panels, openings, footers, lintels,
+    height, panels, openings, footers, lintelPanels,
     deductionLeft, deductionRight, grossLength,
     isRaked, courses, isMultiCourse,
   } = layout;
@@ -59,7 +59,7 @@ export function extractEpsPieces(layout, wallName = '') {
   for (let i = 0; i < panels.length - 1; i++) {
     const panel = panels[i];
     const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
-    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
     const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
     if (!insideLintel && !insideFooter) {
       exclusions.push([gapCentre - HALF_SPLINE, gapCentre + HALF_SPLINE]);
@@ -81,7 +81,7 @@ export function extractEpsPieces(layout, wallName = '') {
     if (deductionLeft === 0 && Math.abs(p.x) < 1) exclusions.push([0, BOTTOM_PLATE]);
   }
 
-  for (const l of lintels) exclusions.push([l.x, l.x + l.width]);
+  for (const l of lintelPanels) exclusions.push([l.x, l.x + l.width]);
 
   exclusions.sort((a, b) => a[0] - b[0]);
 
@@ -187,7 +187,7 @@ export function extractEpsPieces(layout, wallName = '') {
     for (let i = 0; i < panels.length - 1; i++) {
       const panel = panels[i];
       const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
-      const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+      const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
       const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
       if (!insideLintel && !insideFooter) {
         pieces.push({

--- a/devpro-wall-builder/src/utils/epsPlanDxf.js
+++ b/devpro-wall-builder/src/utils/epsPlanDxf.js
@@ -14,7 +14,7 @@ const EPS_INSET = 10;
  * Build cut piece lists from layout (mirrors EpsCutPlans.jsx logic).
  */
 function buildCutPieces(layout) {
-  const { height, panels, openings, footers, lintels, deductionLeft, deductionRight, grossLength, courses, isMultiCourse, isRaked } = layout;
+  const { height, panels, openings, footers, lintelPanels, deductionLeft, deductionRight, grossLength, courses, isMultiCourse, isRaked } = layout;
 
   const epsTop = TOP_PLATE * 2 + EPS_INSET;
   const epsBottom = height - BOTTOM_PLATE - EPS_INSET;
@@ -28,7 +28,7 @@ function buildCutPieces(layout) {
   for (let i = 0; i < panels.length - 1; i++) {
     const panel = panels[i];
     const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
-    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
     const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
     if (!insideLintel && !insideFooter) exclusions.push([gapCentre - HALF_SPLINE, gapCentre + HALF_SPLINE]);
   }
@@ -48,7 +48,7 @@ function buildCutPieces(layout) {
     if (deductionLeft === 0 && Math.abs(p.x) < 1) exclusions.push([0, BOTTOM_PLATE]);
   }
 
-  for (const l of lintels) exclusions.push([l.x, l.x + l.width]);
+  for (const l of lintelPanels) exclusions.push([l.x, l.x + l.width]);
   exclusions.sort((a, b) => a[0] - b[0]);
 
   const getEpsSegments = (panelLeft, panelRight) => {
@@ -131,7 +131,7 @@ function buildCutPieces(layout) {
   for (let i = 0; i < panels.length - 1; i++) {
     const panel = panels[i];
     const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
-    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
     const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
     if (!insideLintel && !insideFooter) {
       splinePieces.push({ label: `Joint P${panels[i].index + 1}/P${panels[i + 1].index + 1}`, width: SPLINE_WIDTH, height: splineH });

--- a/devpro-wall-builder/src/utils/externalElevationDxf.js
+++ b/devpro-wall-builder/src/utils/externalElevationDxf.js
@@ -16,7 +16,7 @@ import {
 export function buildExternalElevationDxf(layout, wallName) {
   const d = createDrawing();
   const {
-    grossLength, height, maxHeight, panels, openings, footers, lintels,
+    grossLength, height, maxHeight, panels, openings, footers, lintelPanels,
     deductionLeft, deductionRight, isRaked, heightAt, profile,
     courses, isMultiCourse,
   } = layout;
@@ -123,8 +123,8 @@ export function buildExternalElevationDxf(layout, wallName) {
     d.drawText(f.x + f.width / 2 - 20, -40, 30, 0, `${f.width}`);
   }
 
-  // ── Lintels ──
-  for (const l of lintels) {
+  // ── Lintel panels ──
+  for (const l of lintelPanels) {
     const hL = l.heightLeft != null ? l.heightLeft : l.height;
     const hR = l.heightRight != null ? l.heightRight : l.height;
     const yBase = l.y;

--- a/devpro-wall-builder/src/utils/framingElevationDxf.js
+++ b/devpro-wall-builder/src/utils/framingElevationDxf.js
@@ -19,7 +19,7 @@ const EPS_INSET = 10;
 export function buildFramingElevationDxf(layout, wallName) {
   const d = createDrawing();
   const {
-    grossLength, height, maxHeight, panels, openings, footers, lintels,
+    grossLength, height, maxHeight, panels, openings, footers, lintelPanels,
     deductionLeft, deductionRight, isRaked, heightAt, courses, isMultiCourse,
   } = layout;
 
@@ -118,7 +118,7 @@ export function buildFramingElevationDxf(layout, wallName) {
     // Vertical edge helper: compute segments excluding lintel/footer zones
     const getExclusions = (xEdge) => {
       const zones = [];
-      for (const l of lintels) {
+      for (const l of lintelPanels) {
         if (l.x < xEdge && xEdge < l.x + l.width) {
           const hL = l.heightLeft != null ? l.heightLeft : l.height;
           const hR = l.heightRight != null ? l.heightRight : l.height;
@@ -206,7 +206,7 @@ export function buildFramingElevationDxf(layout, wallName) {
   for (let i = 0; i < basePanels.length - 1; i++) {
     const panel = basePanels[i];
     const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
-    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
     const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
     if (insideLintel || insideFooter) continue;
 
@@ -320,8 +320,8 @@ export function buildFramingElevationDxf(layout, wallName) {
     d.drawText(f.x + f.width / 2 - 40, f.height / 2, 28, 0, `Footer ${f.ref}`);
   }
 
-  // ── Lintels ──
-  for (const l of lintels) {
+  // ── Lintel panels ──
+  for (const l of lintelPanels) {
     const hL = l.heightLeft != null ? l.heightLeft : l.height;
     const hR = l.heightRight != null ? l.heightRight : l.height;
     const yBase = l.y;
@@ -334,18 +334,18 @@ export function buildFramingElevationDxf(layout, wallName) {
       : [[l.x, yBase], [l.x, yTopL], [l.x + l.width, yTopR], [l.x + l.width, yBase]];
     d.drawPolyline(pts, true);
 
-    // Timber beam
+    // Timber lintel
     const op = openings.find(o => o.ref === l.ref);
     if (op) {
       const hasSill = op.y > 0;
-      const beamH = l.beamHeight || 200;
-      const beamLeft = hasSill ? op.x - BOTTOM_PLATE - SPLINE_WIDTH + EPS_INSET : op.x - BOTTOM_PLATE + EPS_INSET;
-      const beamRight = hasSill ? op.x + op.drawWidth + BOTTOM_PLATE + SPLINE_WIDTH - EPS_INSET : op.x + op.drawWidth + BOTTOM_PLATE - EPS_INSET;
-      const beamBot = l.y;
-      const beamTop = l.y + beamH;
+      const lintelH = l.lintelHeight || 200;
+      const lintelLeft = hasSill ? op.x - BOTTOM_PLATE - SPLINE_WIDTH + EPS_INSET : op.x - BOTTOM_PLATE + EPS_INSET;
+      const lintelRight = hasSill ? op.x + op.drawWidth + BOTTOM_PLATE + SPLINE_WIDTH - EPS_INSET : op.x + op.drawWidth + BOTTOM_PLATE - EPS_INSET;
+      const lintelBot = l.y;
+      const lintelTop = l.y + lintelH;
       d.drawPolyline([
-        [beamLeft, beamBot], [beamRight, beamBot],
-        [beamRight, beamTop], [beamLeft, beamTop],
+        [lintelLeft, lintelBot], [lintelRight, lintelBot],
+        [lintelRight, lintelTop], [lintelLeft, lintelTop],
       ], true);
     }
 
@@ -360,7 +360,7 @@ export function buildFramingElevationDxf(layout, wallName) {
     const jointHasSpline = [];
     for (let i = 0; i < basePanels.length - 1; i++) {
       const gapCentre = basePanels[i].x + basePanels[i].width + PANEL_GAP / 2;
-      const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+      const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
       const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
       jointHasSpline.push(!insideLintel && !insideFooter);
     }
@@ -388,7 +388,7 @@ export function buildFramingElevationDxf(layout, wallName) {
 
         const splineLeft = leftEdge + HSPLINE_CLEARANCE;
         const splineRight = rightEdge - HSPLINE_CLEARANCE;
-        const segs = buildHSplineSegments(splineLeft, splineRight, lintels, openings);
+        const segs = buildHSplineSegments(splineLeft, splineRight, lintelPanels, openings);
 
         segs.forEach(([segL, segR]) => {
           if (segR <= segL) return;

--- a/devpro-wall-builder/src/utils/glueCalculator.js
+++ b/devpro-wall-builder/src/utils/glueCalculator.js
@@ -27,7 +27,7 @@ const DRUM_LITRES = 200;
 
 export function computeWallGlueArea(layout) {
   const {
-    panels = [], openings = [], lintels = [], footers = [], height = 0,
+    panels = [], openings = [], lintelPanels = [], footers = [], height = 0,
     deductionLeft = 0, deductionRight = 0, grossLength = 0, isRaked = false,
   } = layout || {};
 
@@ -41,7 +41,7 @@ export function computeWallGlueArea(layout) {
   const jointSplines = [];
   for (let i = 0; i < panels.length - 1; i++) {
     const gapCentre = panels[i].x + panels[i].width + PANEL_GAP / 2;
-    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
     const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
     if (!insideLintel && !insideFooter) jointSplines.push(gapCentre);
   }
@@ -75,7 +75,7 @@ export function computeWallGlueArea(layout) {
     if (deductionLeft === 0 && Math.abs(p.x) < 1) exclusions.push([0, BOTTOM_PLATE]);
   }
 
-  for (const l of lintels) exclusions.push([l.x, l.x + l.width]);
+  for (const l of lintelPanels) exclusions.push([l.x, l.x + l.width]);
   exclusions.sort((a, b) => a[0] - b[0]);
 
   const getEpsSegments = (panelLeft, panelRight) => {

--- a/devpro-wall-builder/src/utils/magboardOptimizer.js
+++ b/devpro-wall-builder/src/utils/magboardOptimizer.js
@@ -5,7 +5,7 @@
  * (2440mm sheets not stocked — panels use 2745 or 3050 stock sheets.)
  *
  * Each panel face requires one full sheet (2 per panel, front + back).
- * Additional pieces (lintels, footers, splines, deductions) are smaller
+ * Additional pieces (lintel panels, footers, splines, deductions) are smaller
  * and can share sheets via 2D bin packing.
  */
 
@@ -33,7 +33,7 @@ export function extractMagboardPieces(layout, wallName = '') {
   const cutPieces = [];     // smaller pieces to bin-pack
 
   const {
-    height, panels, openings, lintels, footers,
+    height, panels, openings, lintelPanels, footers,
     deductionLeft, deductionRight,
     courses, isMultiCourse,
   } = layout;
@@ -48,17 +48,17 @@ export function extractMagboardPieces(layout, wallName = '') {
     panelSheets.push({ sheetHeight: sheetH, label: `P${panel.index + 1}${courseLabel}`, wallName });
   }
 
-  // ── Lintels: 2 magboard pieces each (EPS area above timber beam) ──
-  for (const lintel of lintels) {
-    const beamH = lintel.beamHeight || 200;
-    const epsHeight = lintel.height - beamH;
+  // ── Lintel panels: 2 magboard pieces each (EPS area above timber lintel) ──
+  for (const lintel of lintelPanels) {
+    const lintelH = lintel.lintelHeight || 200;
+    const epsHeight = lintel.height - lintelH;
     if (epsHeight > 0) {
       for (let i = 0; i < 2; i++) {
         cutPieces.push({
           width: lintel.width,
           height: epsHeight,
-          type: 'lintel',
-          label: `${lintel.ref} Lintel`,
+          type: 'lintelPanel',
+          label: `${lintel.ref} Lintel Panel`,
           wallName,
         });
       }
@@ -89,7 +89,7 @@ export function extractMagboardPieces(layout, wallName = '') {
     for (let i = 0; i < basePanels.length - 1; i++) {
       const panel = basePanels[i];
       const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
-      const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+      const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
       const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
       if (!insideLintel && !insideFooter) {
         jointHasSpline[i] = true;
@@ -147,7 +147,7 @@ export function extractMagboardPieces(layout, wallName = '') {
         // Split around lintels, openings, opening plates & splines
         const splineLeft = leftEdge + HSPLINE_CLEARANCE;
         const splineRight = rightEdge - HSPLINE_CLEARANCE;
-        const segs = buildHSplineSegments(splineLeft, splineRight, lintels, openings);
+        const segs = buildHSplineSegments(splineLeft, splineRight, lintelPanels, openings);
 
         for (const [segL, segR] of segs) {
           const hsplineWidth = segR - segL;
@@ -278,7 +278,7 @@ export function computeProjectMagboardSheets(walls) {
       wallId: wall.id,
       panelSheetCount: panelSheets.length,
       cutPieceCount: cutPieces.length,
-      lintelCount: cutPieces.filter(p => p.type === 'lintel').length,
+      lintelPanelCount: cutPieces.filter(p => p.type === 'lintelPanel').length,
       footerCount: cutPieces.filter(p => p.type === 'footer').length,
       splineCount: cutPieces.filter(p => p.type === 'spline').length,
       deductionCount: cutPieces.filter(p => p.type === 'deduction').length,
@@ -334,7 +334,7 @@ export function computeProjectMagboardSheets(walls) {
     totalSheets,
 
     // Breakdown
-    totalLintels: allCutPieces.filter(p => p.type === 'lintel').length,
+    totalLintelPanels: allCutPieces.filter(p => p.type === 'lintelPanel').length,
     totalFooters: allCutPieces.filter(p => p.type === 'footer').length,
     totalSplines: allCutPieces.filter(p => p.type === 'spline').length,
     totalDeductions: allCutPieces.filter(p => p.type === 'deduction').length,

--- a/devpro-wall-builder/src/utils/magboardOptimizer.test.js
+++ b/devpro-wall-builder/src/utils/magboardOptimizer.test.js
@@ -34,7 +34,7 @@ describe('extractMagboardPieces', () => {
     expect(panelSheets.length).toBe(layout.panels.length * 2);
 
     // No openings → no lintels, no footers
-    const lintelPieces = cutPieces.filter(p => p.type === 'lintel');
+    const lintelPieces = cutPieces.filter(p => p.type === 'lintelPanel');
     const footerPieces = cutPieces.filter(p => p.type === 'footer');
     expect(lintelPieces.length).toBe(0);
     expect(footerPieces.length).toBe(0);
@@ -71,7 +71,7 @@ describe('extractMagboardPieces', () => {
     const { cutPieces } = extractMagboardPieces(layout, 'W1');
 
     // 1 lintel × 2 pieces
-    expect(cutPieces.filter(p => p.type === 'lintel').length).toBe(2);
+    expect(cutPieces.filter(p => p.type === 'lintelPanel').length).toBe(2);
     // 1 footer × 2 pieces (window has sill > 0)
     expect(cutPieces.filter(p => p.type === 'footer').length).toBe(2);
     // Opening splines: window with sill → 2 sides × 2 pieces × 2 (front+back) = 8
@@ -95,7 +95,7 @@ describe('extractMagboardPieces', () => {
     const layout = calculateWallLayout(wall);
     const { cutPieces } = extractMagboardPieces(layout, 'W1');
 
-    expect(cutPieces.filter(p => p.type === 'lintel').length).toBe(2);
+    expect(cutPieces.filter(p => p.type === 'lintelPanel').length).toBe(2);
     expect(cutPieces.filter(p => p.type === 'footer').length).toBe(0);
   });
 
@@ -270,13 +270,13 @@ describe('computeProjectMagboardSheets', () => {
     ];
     const result = computeProjectMagboardSheets(walls);
 
-    const sumLintels = result.perWall.reduce((s, w) => s + w.lintelCount, 0);
+    const sumLintels = result.perWall.reduce((s, w) => s + w.lintelPanelCount, 0);
     const sumFooters = result.perWall.reduce((s, w) => s + w.footerCount, 0);
     const sumSplines = result.perWall.reduce((s, w) => s + w.splineCount, 0);
     const sumDeductions = result.perWall.reduce((s, w) => s + w.deductionCount, 0);
     const sumHsplines = result.perWall.reduce((s, w) => s + w.hsplineCount, 0);
 
-    expect(result.totalLintels).toBe(sumLintels);
+    expect(result.totalLintelPanels).toBe(sumLintels);
     expect(result.totalFooters).toBe(sumFooters);
     expect(result.totalSplines).toBe(sumSplines);
     expect(result.totalDeductions).toBe(sumDeductions);
@@ -309,7 +309,7 @@ describe('computeProjectMagboardSheets', () => {
     const result = computeProjectMagboardSheets(walls);
 
     expect(result.cutPieceCount).toBe(
-      result.totalLintels + result.totalFooters +
+      result.totalLintelPanels + result.totalFooters +
       result.totalSplines + result.totalDeductions +
       result.totalHsplines
     );

--- a/devpro-wall-builder/src/utils/panelPlansDxf.js
+++ b/devpro-wall-builder/src/utils/panelPlansDxf.js
@@ -115,7 +115,7 @@ function collectPieces(layout) {
   const isRaked = layout.isRaked;
   const isMultiCourse = layout.isMultiCourse;
   const courses = layout.courses || [];
-  const lintels = layout.lintels || [];
+  const lintelPanels = layout.lintelPanels || [];
   const footers = layout.footers || [];
   const openings = layout.openings || [];
   const dedLeft = layout.deductionLeft || 0;
@@ -167,8 +167,8 @@ function collectPieces(layout) {
     pieces.push({ type: 'deduction', label: 'End Wall (right)', vertices: rectVerts(dedRight, wallH), w: dedRight, h: wallH, qty: 2 });
   }
 
-  // Lintels
-  lintels.forEach(l => {
+  // Lintel panels
+  lintelPanels.forEach(l => {
     const hL = l.heightLeft != null ? l.heightLeft : l.height;
     const hR = l.heightRight != null ? l.heightRight : l.height;
     const peakH = l.peakHeight || 0;
@@ -176,7 +176,7 @@ function collectPieces(layout) {
     const verts = l.peakHeight
       ? [{ x: 0, y: hL }, { x: l.peakXLocal, y: l.peakHeight }, { x: l.width, y: hR }, { x: l.width, y: 0 }, { x: 0, y: 0 }]
       : [{ x: 0, y: hL }, { x: l.width, y: hR }, { x: l.width, y: 0 }, { x: 0, y: 0 }];
-    pieces.push({ type: 'lintel', label: `${l.ref} — Lintel`, vertices: verts, w: l.width, h: H, qty: 2 });
+    pieces.push({ type: 'lintelPanel', label: `${l.ref} — Lintel Panel`, vertices: verts, w: l.width, h: H, qty: 2 });
   });
 
   // Footers
@@ -190,7 +190,7 @@ function collectPieces(layout) {
   for (let i = 0; i < panels.length - 1; i++) {
     const panel = panels[i];
     const gapCentre = panel.x + panel.width + PANEL_GAP / 2;
-    const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+    const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
     const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
     if (!insideLintel && !insideFooter) splinePieces.push(1);
   }
@@ -207,7 +207,7 @@ function collectPieces(layout) {
     const jointHasSpline = [];
     for (let i = 0; i < panels.length - 1; i++) {
       const gapCentre = panels[i].x + panels[i].width + PANEL_GAP / 2;
-      const insideLintel = lintels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
+      const insideLintel = lintelPanels.some(l => gapCentre > l.x && gapCentre < l.x + l.width);
       const insideFooter = footers.some(f => gapCentre > f.x && gapCentre < f.x + f.width);
       jointHasSpline.push(!insideLintel && !insideFooter);
     }

--- a/devpro-wall-builder/test-gable-lintel.mjs
+++ b/devpro-wall-builder/test-gable-lintel.mjs
@@ -48,8 +48,8 @@ section('Test 1: User scenario — gable lintel straddling peak');
     }],
   });
 
-  assert(layout.lintels.length === 1, `should have 1 lintel, got ${layout.lintels.length}`);
-  const lintel = layout.lintels[0];
+  assert(layout.lintelPanels.length === 1, `should have 1 lintel, got ${layout.lintelPanels.length}`);
+  const lintel = layout.lintelPanels[0];
 
   // Lintel spans x=2879 to x=4321, peak at x=3600
   const expectedPeakXLocal = 3600 - (3000 - WINDOW_OVERHANG);
@@ -95,7 +95,7 @@ section('Test 2: Window on ascending side — no peak in lintel');
     }],
   });
 
-  const lintel = layout.lintels[0];
+  const lintel = layout.lintelPanels[0];
   // Lintel right = 500 + 1200 + 121 = 1821, peak at 3600 → no straddle
   assert(lintel.peakHeight == null, 'lintel should NOT have peakHeight');
   assert(lintel.peakXLocal == null, 'lintel should NOT have peakXLocal');
@@ -122,7 +122,7 @@ section('Test 3: Window on descending side — no peak in lintel');
     }],
   });
 
-  const lintel = layout.lintels[0];
+  const lintel = layout.lintelPanels[0];
   // Lintel left = 5500 - 121 = 5379, peak at 3600 → no straddle
   assert(lintel.peakHeight == null, 'lintel should NOT have peakHeight');
   // Descending side: left should be taller
@@ -148,7 +148,7 @@ section('Test 4: Window centered exactly at peak');
     }],
   });
 
-  const lintel = layout.lintels[0];
+  const lintel = layout.lintelPanels[0];
   assert(lintel.peakHeight != null, 'lintel straddling peak should have peakHeight');
   // Lintel should be symmetric-ish (3600 is center of 3000..4200)
   const diff = Math.abs(lintel.heightLeft - lintel.heightRight);
@@ -171,7 +171,7 @@ section('Test 5: Standard wall — no peak on lintel');
     }],
   });
 
-  const lintel = layout.lintels[0];
+  const lintel = layout.lintelPanels[0];
   assert(lintel.peakHeight == null, 'standard wall lintel should NOT have peakHeight');
   assert(lintel.heightLeft === lintel.heightRight,
     `standard wall: heightLeft (${lintel.heightLeft}) === heightRight (${lintel.heightRight})`);
@@ -194,7 +194,7 @@ section('Test 6: Raked wall — trapezoid lintel, no peak');
     }],
   });
 
-  const lintel = layout.lintels[0];
+  const lintel = layout.lintelPanels[0];
   assert(lintel.peakHeight == null, 'raked wall lintel should NOT have peakHeight');
   // Raked ascending: right side taller
   assert(lintel.heightRight > lintel.heightLeft,
@@ -223,7 +223,7 @@ section('Test 7: Peak at lintel left edge (boundary)');
     }],
   });
 
-  const lintel = layout.lintels[0];
+  const lintel = layout.lintelPanels[0];
   // lintelLeft = 3721 - 121 = 3600 = peakX → strict inequality fails
   assert(lintel.peakHeight == null,
     'peak at lintel left edge (strict inequality) → no peakHeight');
@@ -250,7 +250,7 @@ section('Test 8: Peak at lintel right edge (boundary)');
     }],
   });
 
-  const lintel = layout.lintels[0];
+  const lintel = layout.lintelPanels[0];
   // lintelRight = 2279 + 1200 + 121 = 3600 = peakX → strict inequality fails
   assert(lintel.peakHeight == null,
     'peak at lintel right edge (strict inequality) → no peakHeight');
@@ -274,7 +274,7 @@ section('Test 9: Wide window spanning peak');
     }],
   });
 
-  const lintel = layout.lintels[0];
+  const lintel = layout.lintelPanels[0];
   assert(lintel.peakHeight != null, 'wide window lintel should straddle peak');
   // Large difference between edge heights and peak
   const edgeMax = Math.max(lintel.heightLeft, lintel.heightRight);
@@ -300,7 +300,7 @@ section('Test 10: Door on gable wall — lintel with peak');
     }],
   });
 
-  const lintel = layout.lintels[0];
+  const lintel = layout.lintelPanels[0];
   assert(lintel.peakHeight != null, 'door lintel straddling peak should have peakHeight');
   // Door is taller (2100mm), so lintel height is less
   const expectedPeakH = 4890 - 2100;
@@ -328,7 +328,7 @@ section('Test 11: lintel.height includes peak height');
     }],
   });
 
-  const lintel = layout.lintels[0];
+  const lintel = layout.lintelPanels[0];
   assert(lintel.height >= lintel.heightLeft,
     `height (${lintel.height}) >= heightLeft (${lintel.heightLeft})`);
   assert(lintel.height >= lintel.heightRight,
@@ -358,17 +358,17 @@ section('Test 12: Magboard optimizer bins lintel with peak height');
   });
 
   const { cutPieces } = extractMagboardPieces(layout, 'N-W1');
-  const lintelPieces = cutPieces.filter(p => p.type === 'lintel');
-  assert(lintelPieces.length === 2, `should have 2 lintel pieces (front+back), got ${lintelPieces.length}`);
+  const lintelPanelPieces = cutPieces.filter(p => p.type === 'lintelPanel');
+  assert(lintelPanelPieces.length === 2, `should have 2 lintel panel pieces (front+back), got ${lintelPanelPieces.length}`);
 
   // The lintel piece height should include the peak
-  const lintel = layout.lintels[0];
-  for (const piece of lintelPieces) {
+  const lintel = layout.lintelPanels[0];
+  for (const piece of lintelPanelPieces) {
     assert(piece.height === lintel.height,
-      `lintel piece height (${piece.height}) should match lintel.height (${lintel.height})`);
+      `lintel panel piece height (${piece.height}) should match lintel.height (${lintel.height})`);
     // With peak height ~2790, this needs a 3050mm sheet (> 2745)
     assert(piece.height > 2745,
-      `lintel piece height (${piece.height}) > 2745 → needs 3050mm sheet`);
+      `lintel panel piece height (${piece.height}) > 2745 → needs 3050mm sheet`);
   }
 }
 
@@ -390,7 +390,7 @@ section('Test 13: Short gable — lintel peak fits on 2745mm sheet');
     }],
   });
 
-  const lintel = layout.lintels[0];
+  const lintel = layout.lintelPanels[0];
   if (lintel.peakHeight) {
     // Peak height from opening top: 2700 - (600+800) = 1300mm → fits on 2745mm sheet
     assert(lintel.peakHeight <= 2745,
@@ -417,7 +417,7 @@ section('Test 14: Tall gable — lintel peak needs 3050mm sheet');
     }],
   });
 
-  const lintel = layout.lintels[0];
+  const lintel = layout.lintelPanels[0];
   assert(lintel.height > 2745,
     `lintel height (${lintel.height}) > 2745 → needs 3050mm sheet`);
   assert(lintel.height <= 3050,
@@ -440,7 +440,7 @@ section('Test 15: Standard wall lintel — rectangle');
     }],
   });
 
-  const lintel = layout.lintels[0];
+  const lintel = layout.lintelPanels[0];
   assert(lintel.peakHeight == null, 'no peakHeight on standard wall');
   assert(lintel.heightLeft === lintel.heightRight, 'heights equal on standard wall');
   assert(lintel.height === lintel.heightLeft, 'height equals heightLeft');
@@ -463,7 +463,7 @@ section('Test 16: Raked wall lintel — trapezoid');
     }],
   });
 
-  const lintel = layout.lintels[0];
+  const lintel = layout.lintelPanels[0];
   assert(lintel.peakHeight == null, 'no peakHeight on raked wall');
   assert(lintel.heightRight > lintel.heightLeft,
     `raked: heightRight (${lintel.heightRight}) > heightLeft (${lintel.heightLeft})`);
@@ -501,18 +501,18 @@ section('Test 17: Multiple windows on gable wall');
     ],
   });
 
-  assert(layout.lintels.length === 3, `should have 3 lintels, got ${layout.lintels.length}`);
+  assert(layout.lintelPanels.length === 3, `should have 3 lintels, got ${layout.lintelPanels.length}`);
 
   // W01 (ascending, far left) — no peak
-  const l1 = layout.lintels.find(l => l.ref === 'W01');
+  const l1 = layout.lintelPanels.find(l => l.ref === 'W01');
   assert(l1.peakHeight == null, 'W01 lintel should NOT straddle peak');
 
   // W02 (straddles peak) — has peak
-  const l2 = layout.lintels.find(l => l.ref === 'W02');
+  const l2 = layout.lintelPanels.find(l => l.ref === 'W02');
   assert(l2.peakHeight != null, 'W02 lintel SHOULD straddle peak');
 
   // W03 (descending, far right) — no peak
-  const l3 = layout.lintels.find(l => l.ref === 'W03');
+  const l3 = layout.lintelPanels.find(l => l.ref === 'W03');
   assert(l3.peakHeight == null, 'W03 lintel should NOT straddle peak');
 }
 
@@ -536,7 +536,7 @@ section('Test 18: Lintel where one side has zero height');
     }],
   });
 
-  const lintel = layout.lintels[0];
+  const lintel = layout.lintelPanels[0];
   // Opening top = 3400. At edges, wall may be ~3380. Height = max(0, wallH - 3400)
   // At peak, wall is 4000. Peak lintel height = 4000 - 3400 = 600
   if (lintel.peakHeight) {
@@ -565,7 +565,7 @@ section('Test 19: Short gable — small peak difference');
     }],
   });
 
-  const lintel = layout.lintels[0];
+  const lintel = layout.lintelPanels[0];
   if (lintel.peakHeight) {
     // Small difference between peak and edges
     const diff = lintel.peakHeight - Math.max(lintel.heightLeft, lintel.heightRight);
@@ -592,7 +592,7 @@ section('Test 20: Off-centre peak (x=1800 of 7200mm wall)');
     }],
   });
 
-  const lintel = layout.lintels[0];
+  const lintel = layout.lintelPanels[0];
   // Lintel left = 1200 - 121 = 1079, right = 1200 + 1200 + 121 = 2521
   // Peak at 1800 is inside [1079, 2521]
   assert(lintel.peakHeight != null, 'off-centre peak lintel should have peakHeight');


### PR DESCRIPTION
## Summary
- Renamed `lintels` → `lintelPanels` and `beamHeight` → `lintelHeight` across 20 files to distinguish lintel panels (EPS/magboard above openings) from timber lintels (framing members)
- Updated property names (`lintelCount` → `lintelPanelCount`, `totalLintels` → `totalLintelPanels`), type identifiers (`'lintel'` → `'lintelPanel'`), and UI labels
- All vitest tests pass (20/20); gable lintel tests 48/52 (4 pre-existing failures unrelated to rename)

## Test plan
- [x] `npx vitest run src/utils/magboardOptimizer.test.js` — 20/20 passed
- [x] `node test-gable-lintel.mjs` — 48/52 passed (4 pre-existing failures)
- [ ] Manual smoke test: verify wall drawings, EPS plans, and magboard summary render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)