### PR TITLE
Add footer panel base dimensions to framing elevation

### DIFF
--- a/devpro-wall-builder/src/components/FramingElevation.jsx
+++ b/devpro-wall-builder/src/components/FramingElevation.jsx
@@ -523,6 +523,13 @@ export default function FramingElevation({ layout, wallName, projectName }) {
               >
                 Footer Panel {f.ref}
               </text>
+              <text
+                x={s(f.x + f.width / 2)}
+                y={s(yBottom) + 14}
+                textAnchor="middle" fontSize="9" fill="#999"
+              >
+                {f.width}
+              </text>
             </g>
           ))}
 


### PR DESCRIPTION
## Summary
- Added missing width dimension labels below footer panels in the framing elevation view
- Matches the existing style used for regular panel base dimensions and footer dimensions in WallDrawing

## Test plan
- [ ] Verify footer panels in framing elevation now show width dimensions at their base
- [ ] Confirm regular panel dimensions are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)