### PR TITLE
Fix raked wall bugs: panel width, course height, door jambs

### DIFF
--- a/devpro-wall-builder/src/components/FramingElevation.jsx
+++ b/devpro-wall-builder/src/components/FramingElevation.jsx
@@ -472,19 +472,19 @@ export default function FramingElevation({ layout, wallName, projectName }) {
                     fill={TIMBER_FILL} stroke={C_STRUCTURE} strokeWidth={W_MEDIUM}
                   />
                 )}
-                {/* Door/garage jamb plates — full height of opening */}
+                {/* Door/garage jamb plates — sit on top of bottom plate */}
                 {!hasSill && (
                   <>
                     <rect
                       x={s(op.x - BOTTOM_PLATE)}
                       y={s(yBottom - op.y - op.drawHeight)}
-                      width={s(BOTTOM_PLATE)} height={s(op.drawHeight)}
+                      width={s(BOTTOM_PLATE)} height={s(op.drawHeight - BOTTOM_PLATE)}
                       fill={TIMBER_FILL} stroke={C_STRUCTURE} strokeWidth={W_MEDIUM}
                     />
                     <rect
                       x={s(op.x + op.drawWidth)}
                       y={s(yBottom - op.y - op.drawHeight)}
-                      width={s(BOTTOM_PLATE)} height={s(op.drawHeight)}
+                      width={s(BOTTOM_PLATE)} height={s(op.drawHeight - BOTTOM_PLATE)}
                       fill={TIMBER_FILL} stroke={C_STRUCTURE} strokeWidth={W_MEDIUM}
                     />
                   </>

--- a/devpro-wall-builder/src/utils/calculator.js
+++ b/devpro-wall-builder/src/utils/calculator.js
@@ -429,14 +429,20 @@ export function calculateWallLayout(wall) {
       const fillEnd0 = zone.end - (rightBase > 0 ? rightBase + PANEL_GAP : 0);
       const fillLen0 = fillEnd0 - fillStart0;
       if (fillLen0 > 0 && fillLen0 < MIN_PANEL) {
-        // Distribute remainder to whichever L-cut exists
+        // Distribute remainder to whichever L-cut exists, clamped to max panel width
         if (leftBase > 0 && rightBase > 0) {
-          leftBase += Math.ceil(fillLen0 / 2);
-          rightBase = zoneLen - leftBase;
+          leftBase = Math.min(maxBase, leftBase + Math.ceil(fillLen0 / 2));
+          rightBase = Math.min(maxBase, zoneLen - leftBase);
+          // If clamping re-created a small gap, give it all to leftBase (still clamped)
+          const residual = zoneLen - leftBase - rightBase;
+          if (residual > 0 && residual < MIN_PANEL) {
+            leftBase = Math.min(maxBase, leftBase + residual);
+            rightBase = zoneLen - leftBase;
+          }
         } else if (leftBase > 0) {
-          leftBase = zoneLen;
+          leftBase = Math.min(maxBase, zoneLen);
         } else {
-          rightBase = zoneLen;
+          rightBase = Math.min(maxBase, zoneLen);
         }
       }
 
@@ -478,10 +484,10 @@ export function calculateWallLayout(wall) {
   let preferredBottom = wall.preferred_sheet_height || null;
   if (!preferredBottom && maxHeight > maxStockSheet) {
     if (profile === WALL_PROFILES.RAKED) {
-      // Use the actual lower wall height as the course split point
-      // (the sheet that covers it is tracked separately in sheetHeight)
+      // Use the actual lower wall height as the course split point,
+      // clamped to max stock sheet so course height is always achievable
       const lowerH = Math.min(height, heightAt ? heightAt(grossLength) : height);
-      preferredBottom = lowerH;
+      preferredBottom = lowerH <= maxStockSheet ? lowerH : null;
     } else if (profile === WALL_PROFILES.GABLE) {
       // Use the actual base wall height as the course split point
       preferredBottom = height;

--- a/devpro-wall-builder/src/utils/calculator.test.js
+++ b/devpro-wall-builder/src/utils/calculator.test.js
@@ -423,8 +423,8 @@ describe('calculateWallLayout — course split matches wall geometry', () => {
     expect(layout.courses[0].sheetHeight).toBe(3050);
   });
 
-  it('raked wall: lower height exceeds all sheets → uses max sheet', () => {
-    // Left 7000mm, right 3200mm → lower = 3200 > 3050 → course height = 3200, sheet = 3050 (max)
+  it('raked wall: lower height exceeds all sheets → falls back to standard splitting', () => {
+    // Left 7000mm, right 3200mm → lower = 3200 > 3050 → can't use lowerH as course height
     const wall = makeWall({
       length_mm: 9740,
       height_mm: 7000,
@@ -433,8 +433,11 @@ describe('calculateWallLayout — course split matches wall geometry', () => {
     });
     const layout = calculateWallLayout(wall);
     expect(layout.isMultiCourse).toBe(true);
-    expect(layout.courses[0].height).toBe(3200);
-    expect(layout.courses[0].sheetHeight).toBe(3050);
+    // Every course height must fit on a stock sheet
+    const maxSheet = Math.max(...STOCK_SHEET_HEIGHTS);
+    for (const course of layout.courses) {
+      expect(course.height).toBeLessThanOrEqual(maxSheet);
+    }
   });
 
   it('raked wall: preferred_sheet_height overrides auto-detection', () => {
@@ -695,5 +698,82 @@ describe('calculateWallLayout — Haruru South Wall P2/P3 joint', () => {
     expect(wouldBePlateX).toBeGreaterThan(splineLeft);
     expect(wouldBePlateRight).toBeLessThan(splineRight);
     // The edge plate sits entirely inside the spline — this is wrong
+  });
+});
+
+// ── Raked wall regression fixes ──
+
+describe('raked wall fixes', () => {
+  it('no panel exceeds PANEL_WIDTH (1200mm)', () => {
+    // Raked wall with door that creates L-cut zones prone to absorption overflow
+    const wall = makeWall({
+      length_mm: 7200,
+      height_mm: 3639,
+      height_right_mm: 2700,
+      profile: WALL_PROFILES.RAKED,
+      openings: [{
+        ref: 'D1',
+        type: OPENING_TYPES.DOOR,
+        width_mm: 900,
+        height_mm: 2100,
+        sill_mm: 0,
+        position_from_left_mm: 5000,
+      }],
+    });
+    const layout = calculateWallLayout(wall);
+    for (const panel of layout.panels) {
+      expect(panel.width).toBeLessThanOrEqual(PANEL_WIDTH);
+    }
+  });
+
+  it('no panel exceeds PANEL_WIDTH with various zone sizes', () => {
+    // Test multiple wall lengths to catch different zone size edge cases
+    for (const len of [2600, 3000, 3500, 4800, 6000, 7200, 9740]) {
+      const wall = makeWall({
+        length_mm: len,
+        height_mm: 2440,
+        openings: [{
+          ref: 'D1',
+          type: OPENING_TYPES.DOOR,
+          width_mm: 900,
+          height_mm: 2100,
+          sill_mm: 0,
+          position_from_left_mm: Math.floor(len / 2),
+        }],
+      });
+      const layout = calculateWallLayout(wall);
+      for (const panel of layout.panels) {
+        expect(panel.width).toBeLessThanOrEqual(PANEL_WIDTH);
+      }
+    }
+  });
+
+  it('raked multi-course: every course height fits on a stock sheet', () => {
+    const maxSheet = Math.max(...STOCK_SHEET_HEIGHTS);
+    // Raked wall where the lower height exceeds max stock sheet
+    const wall = makeWall({
+      length_mm: 7200,
+      height_mm: 5000,
+      height_right_mm: 3639,
+      profile: WALL_PROFILES.RAKED,
+    });
+    const layout = calculateWallLayout(wall);
+    expect(layout.isMultiCourse).toBe(true);
+    for (const course of layout.courses) {
+      expect(course.height).toBeLessThanOrEqual(maxSheet);
+    }
+  });
+
+  it('raked wall with lower height within stock sheet range still uses lowerH', () => {
+    // Left 4000mm, right 2600mm → lower = 2600 fits on 2745 sheet
+    const wall = makeWall({
+      length_mm: 9740,
+      height_mm: 4000,
+      height_right_mm: 2600,
+      profile: WALL_PROFILES.RAKED,
+    });
+    const layout = calculateWallLayout(wall);
+    expect(layout.isMultiCourse).toBe(true);
+    expect(layout.courses[0].height).toBe(2600);
   });
 });


### PR DESCRIPTION
## Summary
- Clamp L-cut panel absorption so no panel exceeds 1200mm max width
- Raked walls with lower height > 3050mm fall back to standard course splitting
- Door/garage jamb plates sit on top of bottom plate instead of extending through it
- EPS panel length fix is a flow-on from the panel width fix

## Test plan
- [x] All 111 tests pass including 4 new regression tests
- [ ] Verify no panel exceeds 1200mm on raked walls with doors
- [ ] Verify multi-course raked walls have valid course heights
- [ ] Verify door jambs sit on top of bottom plate in framing elevation
- [ ] Verify EPS panels match corrected panel widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)