### PR TITLE
Add project-level DXF zip export

### DIFF
--- a/devpro-wall-builder/src/components/ExportProjectButton.jsx
+++ b/devpro-wall-builder/src/components/ExportProjectButton.jsx
@@ -1,0 +1,61 @@
+import { useState, useCallback } from 'react';
+import { exportProjectZip } from '../utils/projectExporter.js';
+
+export default function ExportProjectButton({ projectName, walls }) {
+  const [exporting, setExporting] = useState(false);
+  const [progress, setProgress] = useState({ current: 0, total: 0 });
+
+  const handleExport = useCallback(async () => {
+    if (exporting || !walls || walls.length === 0) return;
+
+    setExporting(true);
+    setProgress({ current: 0, total: walls.length * 5 });
+
+    try {
+      await exportProjectZip(projectName, walls, (current, total) => {
+        setProgress({ current, total });
+      });
+    } catch (err) {
+      console.error('Project export failed:', err);
+      alert('Export failed. See console for details.');
+    } finally {
+      setExporting(false);
+    }
+  }, [exporting, projectName, walls]);
+
+  if (!walls || walls.length === 0) return null;
+
+  return (
+    <button
+      onClick={handleExport}
+      disabled={exporting}
+      style={{
+        ...styles.btn,
+        ...(exporting ? styles.btnDisabled : {}),
+      }}
+    >
+      {exporting
+        ? `Exporting... (${progress.current}/${progress.total})`
+        : 'Export All DXFs'}
+    </button>
+  );
+}
+
+const styles = {
+  btn: {
+    padding: '10px 20px',
+    background: '#6B8E23',
+    color: '#fff',
+    border: 'none',
+    borderRadius: 6,
+    cursor: 'pointer',
+    fontSize: 14,
+    fontWeight: 600,
+    whiteSpace: 'nowrap',
+    flexShrink: 0,
+  },
+  btnDisabled: {
+    opacity: 0.6,
+    cursor: 'wait',
+  },
+};

--- a/devpro-wall-builder/src/pages/ProjectPage.jsx
+++ b/devpro-wall-builder/src/pages/ProjectPage.jsx
@@ -10,6 +10,7 @@ import EpsBlockSummary from '../components/EpsBlockSummary.jsx';
 import MagboardSheetSummary from '../components/MagboardSheetSummary.jsx';
 import GlueSummary from '../components/GlueSummary.jsx';
 import ModelViewer3D from '../components/ModelViewer3D.jsx';
+import ExportProjectButton from '../components/ExportProjectButton.jsx';
 
 export default function ProjectPage() {
   const { projectId } = useParams();
@@ -119,12 +120,15 @@ export default function ProjectPage() {
               {walls.length} wall{walls.length !== 1 ? 's' : ''}
             </p>
           </div>
-          <button
-            onClick={() => navigate(`/project/${projectId}/wall/new`)}
-            style={styles.newWallBtn}
-          >
-            + New Wall
-          </button>
+          <div style={styles.headerButtons}>
+            <ExportProjectButton projectName={project.name} walls={walls} />
+            <button
+              onClick={() => navigate(`/project/${projectId}/wall/new`)}
+              style={styles.newWallBtn}
+            >
+              + New Wall
+            </button>
+          </div>
         </div>
 
         {/* 3D Model Viewer */}
@@ -244,6 +248,12 @@ const styles = {
     justifyContent: 'space-between',
     alignItems: 'flex-start',
     padding: '12px 0 24px',
+  },
+  headerButtons: {
+    display: 'flex',
+    gap: 10,
+    alignItems: 'flex-start',
+    flexShrink: 0,
   },
   headerLeft: {},
   title: {

--- a/devpro-wall-builder/src/utils/projectExporter.js
+++ b/devpro-wall-builder/src/utils/projectExporter.js
@@ -1,0 +1,76 @@
+/**
+ * Project-level export: bundles all DXF files for every wall into a zip.
+ *
+ * Uses existing build*Dxf() functions to generate Drawing objects,
+ * converts them to DXF strings via toDxfString(), and packs into a zip
+ * using jszip.
+ */
+import JSZip from 'jszip';
+import { calculateWallLayout } from './calculator.js';
+import { toDxfString } from './dxfExporter.js';
+import { buildExternalElevationDxf } from './externalElevationDxf.js';
+import { buildFramingElevationDxf } from './framingElevationDxf.js';
+import { buildEpsElevationDxf } from './epsElevationDxf.js';
+import { buildEpsPlanDxf } from './epsPlanDxf.js';
+import { buildPanelPlansDxf } from './panelPlansDxf.js';
+
+const DXF_TYPES = [
+  { key: 'External Elevation', build: buildExternalElevationDxf },
+  { key: 'Framing Elevation',  build: buildFramingElevationDxf },
+  { key: 'EPS Elevation',      build: buildEpsElevationDxf },
+  { key: 'EPS Cut Plans',      build: buildEpsPlanDxf },
+  { key: 'Panel Plans',        build: buildPanelPlansDxf },
+];
+
+/**
+ * Sanitize a string for use in filenames (remove characters illegal on Windows).
+ */
+function sanitize(name) {
+  return (name || 'Untitled').replace(/[<>:"/\\|?*]/g, '_');
+}
+
+/**
+ * Export all DXF files for every wall in a project as a zip.
+ *
+ * @param {string} projectName - Display name for the project
+ * @param {Array} walls - Array of wall objects from storage
+ * @param {function} onProgress - Optional callback(current, total) for UI updates
+ * @returns {Promise<void>}
+ */
+export async function exportProjectZip(projectName, walls, onProgress) {
+  const zip = new JSZip();
+  const safeProjName = sanitize(projectName);
+  const total = walls.length * DXF_TYPES.length;
+  let current = 0;
+
+  for (const wall of walls) {
+    const layout = calculateWallLayout(wall);
+    const safeWallName = sanitize(wall.name);
+    const wallFolder = zip.folder(safeWallName);
+
+    for (const { key, build } of DXF_TYPES) {
+      const drawing = build(layout, wall.name);
+      const dxfStr = toDxfString(drawing);
+      const filename = `${safeProjName} ${safeWallName} ${key}.dxf`;
+      wallFolder.file(filename, dxfStr);
+
+      current++;
+      if (onProgress) onProgress(current, total);
+    }
+  }
+
+  const blob = await zip.generateAsync({ type: 'blob' });
+  const zipFilename = `${safeProjName} DXF Export.zip`;
+
+  // Standard blob download — guarantees .zip extension
+  if (typeof document !== 'undefined') {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = zipFilename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+}

--- a/devpro-wall-builder/src/utils/projectExporter.test.js
+++ b/devpro-wall-builder/src/utils/projectExporter.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { exportProjectZip } from './projectExporter.js';
+
+// Mock jszip
+const mockFile = vi.fn();
+const mockFolder = vi.fn(() => ({ file: mockFile }));
+const mockGenerateAsync = vi.fn(() => Promise.resolve(new Blob(['zip'])));
+
+vi.mock('jszip', () => {
+  class MockJSZip {
+    constructor() {
+      this.folder = mockFolder;
+      this.file = mockFile;
+      this.generateAsync = mockGenerateAsync;
+    }
+  }
+  return { default: MockJSZip };
+});
+
+// Minimal wall that calculateWallLayout can process
+function makeWall(name) {
+  return {
+    id: `wall-${name}`,
+    name,
+    length_mm: 3600,
+    height_mm: 2745,
+    profile: 'standard',
+    openings: [],
+  };
+}
+
+describe('exportProjectZip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock URL/DOM APIs for the download fallback
+    global.URL.createObjectURL = vi.fn(() => 'blob:mock');
+    global.URL.revokeObjectURL = vi.fn();
+  });
+
+  it('creates a folder per wall with 5 DXF files each', async () => {
+    const walls = [makeWall('Wall A'), makeWall('Wall B')];
+
+    await exportProjectZip('Test Project', walls);
+
+    // Should create one folder per wall
+    expect(mockFolder).toHaveBeenCalledTimes(2);
+    expect(mockFolder).toHaveBeenCalledWith('Wall A');
+    expect(mockFolder).toHaveBeenCalledWith('Wall B');
+
+    // 5 DXF types per wall = 10 files total
+    expect(mockFile).toHaveBeenCalledTimes(10);
+  });
+
+  it('calls onProgress for each file generated', async () => {
+    const walls = [makeWall('Wall 1')];
+    const onProgress = vi.fn();
+
+    await exportProjectZip('Proj', walls, onProgress);
+
+    // 5 DXF types for 1 wall
+    expect(onProgress).toHaveBeenCalledTimes(5);
+    expect(onProgress).toHaveBeenCalledWith(1, 5);
+    expect(onProgress).toHaveBeenCalledWith(5, 5);
+  });
+
+  it('generates DXF strings (not empty) for each file', async () => {
+    const walls = [makeWall('Test')];
+
+    await exportProjectZip('P', walls);
+
+    // Each file call should have a non-empty string as second arg
+    for (const call of mockFile.mock.calls) {
+      const [filename, content] = call;
+      expect(filename).toMatch(/\.dxf$/);
+      expect(typeof content).toBe('string');
+      expect(content.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('sanitizes filenames with special characters', async () => {
+    const walls = [makeWall('Wall: A/B')];
+
+    await exportProjectZip('Project <1>', walls);
+
+    // Folder name should be sanitized
+    expect(mockFolder).toHaveBeenCalledWith('Wall_ A_B');
+
+    // Filenames should contain sanitized names
+    for (const call of mockFile.mock.calls) {
+      const [filename] = call;
+      expect(filename).not.toMatch(/[<>:"/\\|?*]/);
+    }
+  });
+
+  it('generates the zip blob', async () => {
+    const walls = [makeWall('W')];
+
+    await exportProjectZip('P', walls);
+
+    expect(mockGenerateAsync).toHaveBeenCalledWith({ type: 'blob' });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds "Export All DXFs" button to the project page header
- Generates all 5 DXF types (external elevation, framing, EPS elevation, EPS cut plans, panel plans) for every wall in the project
- Bundles into a zip file organized by wall folders
- Shows progress indicator during export

## Test plan
- [ ] Verify button appears on project page next to "+ New Wall"
- [ ] Verify button is hidden when project has no walls
- [ ] Export a project with multiple walls and confirm zip contains correct folder structure and DXF files
- [ ] Open exported DXFs in a CAD viewer to verify they match individual wall exports
- [ ] Test with standard, raked, and gable wall profiles
- [ ] Confirm button is disabled during export and shows progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)