### PR TITLE
Add H1 design data import and fix DEVPRO_FLOOR_R

### DIFF
--- a/devpro-wall-builder/src/components/H1Form.jsx
+++ b/devpro-wall-builder/src/components/H1Form.jsx
@@ -4,6 +4,7 @@ import {
   GLAZING_TYPES, FRAME_TYPES, lookupWindowR,
   SLAB_FLOOR_TYPES, SLAB_INSULATION_POSITIONS, lookupSlabR,
 } from '../utils/h1Constants.js';
+import { buildH1FromDesign } from '../utils/h1DesignImport.js';
 
 const defaultConstruction = { area: 0, rValue: 0 };
 
@@ -30,8 +31,9 @@ const defaultH1Input = {
   heatedElements: { ceiling: false, wall: false, floor: false, bathroomOnly: false },
 };
 
-export default function H1Form({ climateZone, initialData, onChange, onCalculate }) {
+export default function H1Form({ projectId, climateZone, initialData, onChange, onCalculate }) {
   const [input, setInput] = useState(initialData || defaultH1Input);
+  const [importSummary, setImportSummary] = useState(null);
   const onChangeRef = useRef(onChange);
 
   useEffect(() => {
@@ -112,12 +114,37 @@ export default function H1Form({ climateZone, initialData, onChange, onCalculate
   const glazingRatio = input.grossWallArea > 0 ? ((glazingArea / input.grossWallArea) * 100).toFixed(1) : '0.0';
   const glazingOk = parseFloat(glazingRatio) <= 40;
 
+  const handleImportDesign = () => {
+    if (!projectId) return;
+    const { input: imported, summary } = buildH1FromDesign(projectId, input);
+    setInput(imported);
+    setImportSummary(summary);
+  };
+
   const handleCalculate = () => {
     if (onCalculate) onCalculate(input);
   };
 
   return (
     <div>
+      {/* Import from Design */}
+      {projectId && (
+        <div style={styles.importRow}>
+          <button style={styles.importBtn} onClick={handleImportDesign}>
+            Import from Design
+          </button>
+          {importSummary && (
+            <span style={styles.importSummary}>
+              {importSummary.wallsImported} wall{importSummary.wallsImported !== 1 ? 's' : ''}
+              {importSummary.glazingCount > 0 && `, ${importSummary.glazingCount} window${importSummary.glazingCount !== 1 ? 's' : ''}`}
+              {importSummary.doorCount > 0 && `, ${importSummary.doorCount} door${importSummary.doorCount !== 1 ? 's' : ''}`}
+              {importSummary.floorCount > 0 && `, ${importSummary.floorAreaM2.toFixed(1)} m\u00B2 floor`}
+              {' '}imported
+            </span>
+          )}
+        </div>
+      )}
+
       {/* Building Envelope Areas */}
       <CollapsibleSection sectionKey="h1-areas" title="Building Envelope Areas">
         <div style={styles.section}>
@@ -420,6 +447,27 @@ const styles = {
   zoneNote: {
     fontSize: 13,
     color: '#888',
+    fontWeight: 500,
+  },
+  importRow: {
+    display: 'flex',
+    gap: 12,
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  importBtn: {
+    padding: '10px 20px',
+    background: '#E8F5E9',
+    color: '#2E7D32',
+    border: '1px solid #A5D6A7',
+    borderRadius: 6,
+    cursor: 'pointer',
+    fontSize: 14,
+    fontWeight: 600,
+  },
+  importSummary: {
+    fontSize: 13,
+    color: '#555',
     fontWeight: 500,
   },
 };

--- a/devpro-wall-builder/src/pages/H1Page.jsx
+++ b/devpro-wall-builder/src/pages/H1Page.jsx
@@ -86,6 +86,7 @@ export default function H1Page() {
         ) : (
           <>
             <H1Form
+              projectId={projectId}
               climateZone={climateZone}
               initialData={h1Input}
               onChange={handleChange}

--- a/devpro-wall-builder/src/utils/h1Constants.js
+++ b/devpro-wall-builder/src/utils/h1Constants.js
@@ -150,6 +150,10 @@ export const REFERENCE_GLAZING_RATIO = 0.30;
 export const MAX_GLAZING_RATIO = 0.40;
 export const REFERENCE_TIMBER_FRACTION = 0.18; // NZS 3604 standard timber framing fraction for walls
 
+// ── DEVPRO Product R-values ──
+export const DEVPRO_WALL_R = 4.14;   // 142mm EPS wall panel (weighted with timber bridging)
+export const DEVPRO_FLOOR_R = 5.02;  // 172mm EPS suspended floor panel (R4.82 EPS + surface resistances)
+
 
 // ── Window R-value Lookup Table ──
 // Source: H1/AS1 6th Edition, Appendix D

--- a/devpro-wall-builder/src/utils/h1DesignImport.js
+++ b/devpro-wall-builder/src/utils/h1DesignImport.js
@@ -1,0 +1,132 @@
+/**
+ * Import design data from project walls and floors to pre-populate H1 calculator inputs.
+ *
+ * Derives: grossWallArea, wall constructions, glazing, opaque doors, slab floor area + perimeter.
+ * Preserves: roof, skylight, floorOther, heatedElements, slab config (type, insulation, wallThickness).
+ */
+
+import { getProjectWalls, getProjectFloors } from './storage.js';
+import { computeWallTimberRatio } from './timberCalculator.js';
+import { calculateFloorLayout } from './floorCalculator.js';
+import { lookupSlabR } from './h1Constants.js';
+
+const DEVPRO_WALL_R = 4.14;
+
+/**
+ * Build H1 input fields from project design data.
+ *
+ * @param {string} projectId
+ * @param {object} existing - current H1 form input (to preserve non-derivable fields)
+ * @returns {{ input: object, summary: object }} merged input + import summary
+ */
+export function buildH1FromDesign(projectId, existing) {
+  const walls = getProjectWalls(projectId);
+  const floors = getProjectFloors(projectId);
+
+  // ── Walls ──
+  let grossWallAreaMM2 = 0;
+  const wallConstructions = [];
+  const glazingEntries = [];
+  const doorEntries = [];
+
+  for (const wall of walls) {
+    let tr;
+    try {
+      tr = computeWallTimberRatio(wall);
+    } catch {
+      continue; // skip walls that can't be computed
+    }
+
+    grossWallAreaMM2 += tr.grossWallArea; // mm²
+
+    // Wall construction entry (net wall area for this wall)
+    const wallAreaM2 = tr.effectiveWallArea / 1e6;
+    if (wallAreaM2 > 0) {
+      wallConstructions.push({ area: round2(wallAreaM2), rValue: DEVPRO_WALL_R });
+    }
+
+    // Openings → glazing or opaque door
+    for (const op of (wall.openings || [])) {
+      const areaM2 = (op.width_mm * op.height_mm) / 1e6;
+      if (areaM2 <= 0) continue;
+
+      if (op.type === 'window') {
+        glazingEntries.push({
+          area: round2(areaM2),
+          glazingType: 'double',
+          ug: 2.9,
+          frameType: 'aluminiumThermal',
+          rValue: 0.30,
+        });
+      } else {
+        // door, single_garage, double_garage → opaque door
+        doorEntries.push({ area: round2(areaM2), rValue: 0.50 });
+      }
+    }
+  }
+
+  const grossWallAreaM2 = round2(grossWallAreaMM2 / 1e6);
+
+  // ── Floors ──
+  let totalFloorAreaMM2 = 0;
+  let totalPerimeterMM = 0;
+
+  for (const floor of floors) {
+    try {
+      const layout = calculateFloorLayout(floor);
+      totalFloorAreaMM2 += layout.totalArea;
+      totalPerimeterMM += layout.perimeterLength;
+    } catch {
+      continue;
+    }
+  }
+
+  const floorAreaM2 = round2(totalFloorAreaMM2 / 1e6);
+  const perimeterM = round2(totalPerimeterMM / 1e3);
+
+  // ── Merge with existing input ──
+  const slab = {
+    ...(existing?.slab || {}),
+    floorArea: floorAreaM2 || existing?.slab?.floorArea || 0,
+    perimeter: perimeterM || existing?.slab?.perimeter || 0,
+    floorType: existing?.slab?.floorType || 'raft_no_masonry',
+    insulationPosition: existing?.slab?.insulationPosition || 'uninsulated',
+    wallThickness: existing?.slab?.wallThickness || 162,
+  };
+
+  // Auto-lookup slab R-value
+  const apRatio = slab.perimeter > 0 ? slab.floorArea / slab.perimeter : 0;
+  const slabR = lookupSlabR(slab.floorType, slab.insulationPosition, apRatio, slab.wallThickness);
+
+  const input = {
+    grossWallArea: grossWallAreaM2,
+    constructions: {
+      roof: existing?.constructions?.roof || [{ area: 0, rValue: 6.6 }],
+      wall: wallConstructions.length > 0 ? wallConstructions : [{ area: 0, rValue: DEVPRO_WALL_R }],
+      glazing: glazingEntries.length > 0 ? glazingEntries : [{ area: 0, glazingType: 'double', ug: 2.9, frameType: 'aluminiumThermal', rValue: 0.30 }],
+      doorOpaque: doorEntries,
+      skylight: existing?.constructions?.skylight || [],
+      floorSlab: [{ area: slab.floorArea, rValue: slabR || 0 }],
+      floorOther: existing?.constructions?.floorOther || [],
+    },
+    slab,
+    heatedElements: existing?.heatedElements || { ceiling: false, wall: false, floor: false, bathroomOnly: false },
+  };
+
+  const summary = {
+    wallCount: walls.length,
+    wallsImported: wallConstructions.length,
+    grossWallAreaM2,
+    glazingCount: glazingEntries.length,
+    doorCount: doorEntries.length,
+    floorCount: floors.length,
+    floorAreaM2,
+    perimeterM,
+  };
+
+  return { input, summary };
+}
+
+function round2(n) {
+  return Math.round(n * 100) / 100;
+}

--- a/devpro-wall-builder/src/utils/h1DesignImport.js
+++ b/devpro-wall-builder/src/utils/h1DesignImport.js
@@ -8,9 +8,7 @@
 import { getProjectWalls, getProjectFloors } from './storage.js';
 import { computeWallTimberRatio } from './timberCalculator.js';
 import { calculateFloorLayout } from './floorCalculator.js';
-import { lookupSlabR } from './h1Constants.js';
-
-const DEVPRO_WALL_R = 4.14;
+import { DEVPRO_WALL_R, DEVPRO_FLOOR_R } from './h1Constants.js';
 
 /**
  * Build H1 input fields from project design data.
@@ -85,18 +83,10 @@ export function buildH1FromDesign(projectId, existing) {
   const perimeterM = round2(totalPerimeterMM / 1e3);
 
   // ── Merge with existing input ──
-  const slab = {
-    ...(existing?.slab || {}),
-    floorArea: floorAreaM2 || existing?.slab?.floorArea || 0,
-    perimeter: perimeterM || existing?.slab?.perimeter || 0,
-    floorType: existing?.slab?.floorType || 'raft_no_masonry',
-    insulationPosition: existing?.slab?.insulationPosition || 'uninsulated',
-    wallThickness: existing?.slab?.wallThickness || 162,
-  };
-
-  // Auto-lookup slab R-value
-  const apRatio = slab.perimeter > 0 ? slab.floorArea / slab.perimeter : 0;
-  const slabR = lookupSlabR(slab.floorType, slab.insulationPosition, apRatio, slab.wallThickness);
+  // DEVPRO floors are suspended (not slab-on-ground) → populate floorOther
+  const floorOtherEntries = floorAreaM2 > 0
+    ? [{ area: floorAreaM2, rValue: DEVPRO_FLOOR_R }]
+    : existing?.constructions?.floorOther || [];
 
   const input = {
     grossWallArea: grossWallAreaM2,
@@ -106,10 +96,13 @@ export function buildH1FromDesign(projectId, existing) {
       glazing: glazingEntries.length > 0 ? glazingEntries : [{ area: 0, glazingType: 'double', ug: 2.9, frameType: 'aluminiumThermal', rValue: 0.30 }],
       doorOpaque: doorEntries,
       skylight: existing?.constructions?.skylight || [],
-      floorSlab: [{ area: slab.floorArea, rValue: slabR || 0 }],
-      floorOther: existing?.constructions?.floorOther || [],
+      floorSlab: existing?.constructions?.floorSlab || [{ area: 0, rValue: 0 }],
+      floorOther: floorOtherEntries,
     },
-    slab,
+    slab: existing?.slab || {
+      perimeter: 0, floorArea: 0,
+      floorType: 'raft_no_masonry', insulationPosition: 'uninsulated', wallThickness: 162,
+    },
     heatedElements: existing?.heatedElements || { ceiling: false, wall: false, floor: false, bathroomOnly: false },
   };
 


### PR DESCRIPTION
## Summary
- Add "Import from Design" button to H1 calculator that pre-populates inputs from project walls and floors
- Wall areas, glazing, and opaque doors derived from wall timber ratios
- Floor area imported into suspended floor (floorOther) field, not slab
- Add missing DEVPRO_WALL_R and DEVPRO_FLOOR_R exports to h1Constants.js

## Test plan
- [ ] Open H1 page for a project with walls and floors → click "Import from Design" → verify wall, glazing, door, and floor fields populate
- [ ] Verify roof, skylight, slab, and heated element fields are preserved
- [ ] Verify FloorBuilderPage no longer crashes (DEVPRO_FLOOR_R export fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)